### PR TITLE
[Themes] Correct Start button sizes for FreeCAD 1.0

### DIFF
--- a/Behave-dark/Behave-dark.cfg
+++ b/Behave-dark/Behave-dark.cfg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<FCParameters>
+  <FCParamGroup Name="Root">
+    <FCParamGroup Name="BaseApp">
+      <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Arch">
+            <FCUInt Name="WallColor" Value="3604403967"/>
+            <FCUInt Name="StructureColor" Value="2527705855"/>
+            <FCUInt Name="RebarColor" Value="3111475967"/>
+            <FCUInt Name="WindowColor" Value="556614399"/>
+            <FCUInt Name="WindowGlassColor" Value="1572326399"/>
+            <FCUInt Name="PanelColor" Value="3416289279"/>
+            <FCUInt Name="ColorHelpers" Value="1347440895"/>
+            <FCUInt Name="defaultSpaceColor" Value="4280090879"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Draft">
+            <FCInt Name="gridTransparency" Value="0"/>
+            <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="gridColor" Value="4294967295"/>
+            <FCUInt Name="snapcolor" Value="4294967295"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9b4de6</FCText>
+          </FCParamGroup>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="3570717951"/>
+          <FCUInt Name="colorLogging" Value="1437270015"/>
+          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="3570717696"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="1453118976"/>
+          <FCUInt Name="Comment" Value="1788433664"/>
+          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Number" Value="3050219520"/>
+          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="1321840640"/>
+          <FCUInt Name="Define name" Value="3705448960"/>
+          <FCUInt Name="Operator" Value="3570717696"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4252787200"/>
+          <FCUInt Name="Current line highlight" Value="524114944"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
+          <FCUInt Name="SketchVertexColor" Value="4294967295"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
+          <FCUInt Name="EditedVertexColor" Value="4280680703"/>
+          <FCUInt Name="ConstructionColor" Value="746455039"/>
+          <FCUInt Name="ExternalColor" Value="3425924095"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
+          <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="11206655"/>
+          <FCUInt Name="ConstrainedDimColor" Value="4278255615"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4286523135"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/>
+          <FCUInt Name="CursorTextColor" Value="1437270015"/>
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
+          <FCUInt Name="CreateLineColor" Value="3435973887"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="1"/>
+          <FCBool Name="UseBackgroundColorMid" Value="1"/>
+          <FCUInt Name="BacklightColor" Value="4294967295"/>
+          <FCUInt Name="BackgroundColor" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor2" Value="2088533247"/>
+          <FCUInt Name="BackgroundColor3" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor4" Value="2088533247"/>
+          <FCUInt Name="HighlightColor" Value="327679"/>
+          <FCUInt Name="SelectionColor" Value="16711935"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435980543"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="1434171135"/>
+          <FCUInt Name="TreeActiveColor" Value="3465640191"/>
+        </FCParamGroup>
+        <FCParamGroup Name="MainWindow">
+          <FCBool Name="TiledBackground" Value="0"/>
+          <FCText Name="StyleSheet">Behave-dark.qss</FCText>
+        </FCParamGroup>
+      </FCParamGroup>
+    </FCParamGroup>
+  </FCParamGroup>
+</FCParameters>

--- a/Behave-dark/Behave-dark.qss
+++ b/Behave-dark/Behave-dark.qss
@@ -1544,6 +1544,12 @@ QPushButton:focus {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
+#CreateNewRow > QPushButton { // linked to https://github.com/FreeCAD/FreeCAD/pull/15356
+  /* Reset min width to default */
+  min-width: -1;
+  min-height: 50px;
+}
+
 QPushButton:disabled,
 QPushButton:disabled:checked {
     color: #787878;

--- a/Behave-dark/Behave-dark.qss
+++ b/Behave-dark/Behave-dark.qss
@@ -1544,7 +1544,7 @@ QPushButton:focus {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
-#CreateNewRow > QPushButton { // linked to https://github.com/FreeCAD/FreeCAD/pull/15356
+#CreateNewRow > QPushButton { /* linked to https://github.com/FreeCAD/FreeCAD/pull/15356 */
   /* Reset min width to default */
   min-width: -1;
   min-height: 50px;

--- a/Dark-contrast/Dark-contrast.cfg
+++ b/Dark-contrast/Dark-contrast.cfg
@@ -103,4 +103,3 @@
     </FCParamGroup>
   </FCParamGroup>
 </FCParameters>
-

--- a/Dark-contrast/Dark-contrast.cfg
+++ b/Dark-contrast/Dark-contrast.cfg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<FCParameters>
+  <FCParamGroup Name="Root">
+    <FCParamGroup Name="BaseApp">
+      <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Arch">
+            <FCUInt Name="WallColor" Value="3604403967"/>
+            <FCUInt Name="StructureColor" Value="2527705855"/>
+            <FCUInt Name="RebarColor" Value="3111475967"/>
+            <FCUInt Name="WindowColor" Value="556614399"/>
+            <FCUInt Name="WindowGlassColor" Value="1572326399"/>
+            <FCUInt Name="PanelColor" Value="3416289279"/>
+            <FCUInt Name="ColorHelpers" Value="1347440895"/>
+            <FCUInt Name="defaultSpaceColor" Value="4280090879"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Draft">
+            <FCInt Name="gridTransparency" Value="0"/>
+            <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="gridColor" Value="4294967295"/>
+            <FCUInt Name="snapcolor" Value="4294967295"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9b4de6</FCText>
+          </FCParamGroup>
+          <FCParamGroup Name="Start">
+            <FCUInt Name="BackgroundColor1" Value="1010580735"/>
+            <FCUInt Name="BackgroundTextColor" Value="4294703103"/>
+            <FCUInt Name="PageColor" Value="858993663"/>
+            <FCUInt Name="PageTextColor" Value="3570717951"/>
+            <FCUInt Name="BoxColor" Value="1583243007"/>
+            <FCUInt Name="LinkColor" Value="1437270015"/>
+            <FCUInt Name="BackgroundColor2" Value="2141107711"/>
+          </FCParamGroup>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="3570717951"/>
+          <FCUInt Name="colorLogging" Value="1437270015"/>
+          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="3570717696"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="1453118976"/>
+          <FCUInt Name="Comment" Value="1788433664"/>
+          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Number" Value="3050219520"/>
+          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="1321840640"/>
+          <FCUInt Name="Define name" Value="3705448960"/>
+          <FCUInt Name="Operator" Value="3570717696"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4252787200"/>
+          <FCUInt Name="Current line highlight" Value="524114944"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
+          <FCUInt Name="SketchVertexColor" Value="4294967295"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
+          <FCUInt Name="EditedVertexColor" Value="4280680703"/>
+          <FCUInt Name="ConstructionColor" Value="746455039"/>
+          <FCUInt Name="ExternalColor" Value="3425924095"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
+          <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="11206655"/>
+          <FCUInt Name="ConstrainedDimColor" Value="4278255615"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4286523135"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/>
+          <FCUInt Name="CursorTextColor" Value="1437270015"/>
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
+          <FCUInt Name="CreateLineColor" Value="3435973887"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="1"/>
+          <FCBool Name="UseBackgroundColorMid" Value="1"/>
+          <FCUInt Name="BacklightColor" Value="4294967295"/>
+          <FCUInt Name="BackgroundColor" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor2" Value="2088533247"/>
+          <FCUInt Name="BackgroundColor3" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor4" Value="2088533247"/>
+          <FCUInt Name="HighlightColor" Value="327679"/>
+          <FCUInt Name="SelectionColor" Value="16711935"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="1434171135"/>
+          <FCUInt Name="TreeActiveColor" Value="3465640191"/>
+        </FCParamGroup>
+        <FCParamGroup Name="MainWindow">
+          <FCBool Name="TiledBackground" Value="0"/>
+          <FCText Name="StyleSheet">Dark-contrast.qss</FCText>
+        </FCParamGroup>
+      </FCParamGroup>
+    </FCParamGroup>
+  </FCParamGroup>
+</FCParameters>
+

--- a/Dark-modern/Dark-modern.cfg
+++ b/Dark-modern/Dark-modern.cfg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<FCParameters>
+  <FCParamGroup Name="Root">
+    <FCParamGroup Name="BaseApp">
+      <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Arch">
+            <FCUInt Name="WallColor" Value="3604403967"/>
+            <FCUInt Name="StructureColor" Value="2527705855"/>
+            <FCUInt Name="RebarColor" Value="3111475967"/>
+            <FCUInt Name="WindowColor" Value="556614399"/>
+            <FCUInt Name="WindowGlassColor" Value="1572326399"/>
+            <FCUInt Name="PanelColor" Value="3416289279"/>
+            <FCUInt Name="ColorHelpers" Value="1347440895"/>
+            <FCUInt Name="defaultSpaceColor" Value="4280090879"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Draft">
+            <FCInt Name="gridTransparency" Value="0"/>
+            <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="gridColor" Value="4294967295"/>
+            <FCUInt Name="snapcolor" Value="4294967295"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9b4de6</FCText>
+          </FCParamGroup>
+          <FCParamGroup Name="Start">
+            <FCUInt Name="BackgroundColor1" Value="1010580735"/>
+            <FCUInt Name="BackgroundTextColor" Value="4294703103"/>
+            <FCUInt Name="PageColor" Value="858993663"/>
+            <FCUInt Name="PageTextColor" Value="3570717951"/>
+            <FCUInt Name="BoxColor" Value="1583243007"/>
+            <FCUInt Name="LinkColor" Value="1437270015"/>
+            <FCUInt Name="BackgroundColor2" Value="2141107711"/>
+          </FCParamGroup>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="3570717951"/>
+          <FCUInt Name="colorLogging" Value="1437270015"/>
+          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="3570717696"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="1453118976"/>
+          <FCUInt Name="Comment" Value="1788433664"/>
+          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Number" Value="3050219520"/>
+          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="1321840640"/>
+          <FCUInt Name="Define name" Value="3705448960"/>
+          <FCUInt Name="Operator" Value="3570717696"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4252787200"/>
+          <FCUInt Name="Current line highlight" Value="524114944"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
+          <FCUInt Name="SketchVertexColor" Value="4294967295"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
+          <FCUInt Name="EditedVertexColor" Value="4280680703"/>
+          <FCUInt Name="ConstructionColor" Value="746455039"/>
+          <FCUInt Name="ExternalColor" Value="3425924095"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
+          <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="11206655"/>
+          <FCUInt Name="ConstrainedDimColor" Value="4278255615"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4286523135"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/>
+          <FCUInt Name="CursorTextColor" Value="1437270015"/>
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
+          <FCUInt Name="CreateLineColor" Value="3435973887"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="1"/>
+          <FCBool Name="UseBackgroundColorMid" Value="1"/>
+          <FCUInt Name="BacklightColor" Value="4294967295"/>
+          <FCUInt Name="BackgroundColor" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor2" Value="2088533247"/>
+          <FCUInt Name="BackgroundColor3" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor4" Value="2088533247"/>
+          <FCUInt Name="HighlightColor" Value="327679"/>
+          <FCUInt Name="SelectionColor" Value="16711935"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="1434171135"/>
+          <FCUInt Name="TreeActiveColor" Value="3465640191"/>
+        </FCParamGroup>
+        <FCParamGroup Name="MainWindow">
+          <FCBool Name="TiledBackground" Value="0"/>
+          <FCText Name="StyleSheet">Dark-modern.qss</FCText>
+        </FCParamGroup>
+      </FCParamGroup>
+    </FCParamGroup>
+  </FCParamGroup>
+</FCParameters>

--- a/Dark-modern/Dark-modern.qss
+++ b/Dark-modern/Dark-modern.qss
@@ -34,18 +34,18 @@ Resetting everything helps to unify styles across different operating systems
 
 --------------------------------------------------------------------------- */
 * {
-  padding: 0px;
-  margin: 0px;
-  border: 0px;
-  border-style: none;
-  border-image: none;
-  outline: 0;
+    padding: 0px;
+    margin: 0px;
+    border: 0px;
+    border-style: none;
+    border-image: none;
+    outline: 0;
 }
 
 /* specific reset for elements inside QToolBar */
 QToolBar * {
-  margin: 0px;
-  padding: 0px;
+    margin: 0px;
+    padding: 0px;
 }
 
 /*hacks */
@@ -84,13 +84,13 @@ Gui--PropertyEditor--PropertyEditor QComboBox {
 
 /* fix for column items background when a link is present */
 Gui--PropertyEditor--PropertyEditor > QWidget > QFrame:focus {
-  background-color: @ThemeAccentColor1; /* same as focused background color */
+    background-color: @ThemeAccentColor1; /* same as focused background color */
 }
 
 /* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
-	color: #ffffff;
-	background-color: #ACC8E5; /* same as focused background color */
+  	color: #ffffff;
+  	background-color: #ACC8E5; /* same as focused background color */
 }
 
 /*==================================================================================================
@@ -104,42 +104,42 @@ QToolBar  {
 }
 
 QMdiArea {
-  background-image: url(qss:images_dark-light/background_freecad_dark.svg);
-  background-position: center center;
-  background-repeat: no-repeat;
+    background-image: url(qss:images_dark-light/background_freecad_dark.svg);
+    background-position: center center;
+    background-repeat: no-repeat;
 }
 /*navgation src/Mod/Tux/NavigationIndicatorGui.py */
 Gui--NavigationIndicatorGui--BlenderNavigationStyle {
 /*QAction#a4 {*/
-  qproperty-icon: url(:/icons/icons/NavigationBlender_light.svg);
+    qproperty-icon: url(:/icons/icons/NavigationBlender_light.svg);
 }
 /*=====
 /* QWidget ----------------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QWidget {
-  background-color: #2b2b2b;
-  border: 0px solid #696968;
-  padding: 0px;
-  color: White;
-  selection-background-color: @ThemeAccentColor1;
-  selection-color: White;
+    background-color: #2b2b2b;
+    border: 0px solid #696968;
+    padding: 0px;
+    color: White;
+    selection-background-color: @ThemeAccentColor1;
+    selection-color: White;
 }
 
 QWidget:disabled {
-  color: #c2c7cb;
-  selection-background-color: @ThemeAccentColor1;
-  selection-color: #c2c7cb;
+    color: #c2c7cb;
+    selection-background-color: @ThemeAccentColor1;
+    selection-color: #c2c7cb;
 }
 
 QWidget::item:selected {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
-  /* Causes issue with colorselector.
-  QWidget::item:hover:!selected {
+/* Causes issue with colorselector.
+QWidget::item:hover:!selected {
     background-color: @ThemeAccentColor1;
-  }*/
+}*/
 
 /* QMainWindow ------------------------------------------------------------
 
@@ -148,36 +148,36 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qmainwindow
 
 --------------------------------------------------------------------------- */
 QMainWindow::separator {
-  /*background-color: #3c3c3c;*/
-  border: 0px solid #696968;
-  spacing: 0px;
-  padding: 1px;
+    /*background-color: #3c3c3c;*/
+    border: 0px solid #696968;
+    spacing: 0px;
+    padding: 1px;
 }
 
 QMainWindow::separator:vertical:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
-  /*background-color: @ThemeAccentColor1;*/
-  image: url(qss:images_dark-light/splitter_vertical_light.svg);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
+    /*background-color: @ThemeAccentColor1;*/
+    image: url(qss:images_dark-light/splitter_vertical_light.svg);
 }
 
 QMainWindow::separator:horizontal:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
-  /*background-color: @ThemeAccentColor1;*/
-  image: url(qss:images_dark-light/splitter_horizontal_light.svg);
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
+    /*background-color: @ThemeAccentColor1;*/
+    image: url(qss:images_dark-light/splitter_horizontal_light.svg);
 }
 
 QMainWindow::separator:horizontal {
-  width: 4px;
-  margin-top: 0.1px;
-  margin-bottom: 0.1px;
- /* image: url(qss:images_dark-light/splitter_horizontal_dark.svg);*/
+    width: 4px;
+    margin-top: 0.1px;
+    margin-bottom: 0.1px;
+    /* image: url(qss:images_dark-light/splitter_horizontal_dark.svg);*/
 }
 
 QMainWindow::separator:vertical {
-  height: 4px;
-  margin-left: 0.1px;
-  margin-right: 0.1px;
- /* image: url(qss:images_dark-light/splitter_vertical_dark.svg);*/
+    height: 4px;
+    margin-left: 0.1px;
+    margin-right: 0.1px;
+    /* image: url(qss:images_dark-light/splitter_vertical_dark.svg);*/
 }
 
 /* QToolTip ---------------------------------------------------------------
@@ -186,13 +186,13 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtooltip
 
 --------------------------------------------------------------------------- */
 QToolTip {
-  background-color: #1c1b22;
-  color: White;
-  /* If you remove the border property, background stops working on Windows */
-  border: none;
-  /* Remove padding, for fix combo box tooltip */
-  padding: 0px;
-  /* Remove opacity, fix #174 - may need to use RGBA */
+    background-color: #1c1b22;
+    color: White;
+    /* If you remove the border property, background stops working on Windows */
+    border: none;
+    /* Remove padding, for fix combo box tooltip */
+    padding: 0px;
+    /* Remove opacity, fix #174 - may need to use RGBA */
 }
 
 /* QStatusBar -------------------------------------------------------------
@@ -201,29 +201,29 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qstatusbar
 
 --------------------------------------------------------------------------- */
 QStatusBar {
-  border: 0px solid #3c3c3c;
-  /* Fixes Spyder #9120, #9121 */
-  background: #2b2b2b;
-  /* Fixes #205, white vertical borders separating items */
+    border: 0px solid #3c3c3c;
+    /* Fixes Spyder #9120, #9121 */
+    background: #2b2b2b;
+    /* Fixes #205, white vertical borders separating items */
 }
 
 QStatusBar::item {
-  border: none;
+    border: none;
 }
 
 QStatusBar QToolTip {
-  background-color: #2b2b2b;
-  border: 1px solid #696968;
-  color: #2b2b2b;
-  /* Remove padding, for fix combo box tooltip */
-  padding: 0px;
-  /* Reducing transparency to read better */
-  opacity: 230;
+    background-color: #2b2b2b;
+    border: 1px solid #696968;
+    color: #2b2b2b;
+    /* Remove padding, for fix combo box tooltip */
+    padding: 0px;
+    /* Reducing transparency to read better */
+    opacity: 230;
 }
 
 QStatusBar QLabel {
-  /* Fixes Spyder #9120, #9121 */
-  background: transparent;
+    /* Fixes Spyder #9120, #9121 */
+    background: transparent;
 }
 
 /* QCheckBox --------------------------------------------------------------
@@ -232,72 +232,72 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qcheckbox
 
 --------------------------------------------------------------------------- */
 QCheckBox {
-  color: white;
-  padding: 0px;
-  outline: none;
-  border: 1px solid transparent;
-  background-color: transparent;
+    color: white;
+    padding: 0px;
+    outline: none;
+    border: 1px solid transparent;
+    background-color: transparent;
 }
 
 QCheckBox:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QCheckBox QWidget:disabled {
-  color: #c2c7cb;
+    color: #c2c7cb;
 }
 
 QCheckBox::indicator {
-  color: white;
-  background-color: #1c1b22;
-  width: 12px;
-  height: 12px;
-  image:url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    color: white;
+    background-color: #1c1b22;
+    width: 12px;
+    height: 12px;
+    image:url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QCheckBox::indicator:unchecked {
-  background-color: #1c1b22;
-  image:url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    background-color: #1c1b22;
+    image:url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QCheckBox::indicator:unchecked:hover, QCheckBox::indicator:unchecked:focus, QCheckBox::indicator:unchecked:pressed {
-  background-color: @ThemeAccentColor1;
-  image:url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    background-color: @ThemeAccentColor1;
+    image:url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled {
-  background-color: #2b2b2b;
-  image:url(qss:images_dark-light/checkbox_unchecked_disabled.svg);
+    background-color: #2b2b2b;
+    image:url(qss:images_dark-light/checkbox_unchecked_disabled.svg);
 }
 
 QCheckBox::indicator:checked {
-  background-color: #1c1b22;
-  /*border: 1px solid #696968; /* QRadioButton has the same color */
-  image:url(qss:images_dark-light/checkbox_light.svg);
+    background-color: #1c1b22;
+    /*border: 1px solid #696968; /* QRadioButton has the same color */
+    image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
 QCheckBox::indicator:checked:hover, QCheckBox::indicator:checked:pressed {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QCheckBox::indicator:checked:disabled {
-  background-color: #2b2b2b;
-  image: url(qss:images_dark-light/checkbox_checked_disabled.svg);
+    background-color: #2b2b2b;
+    image: url(qss:images_dark-light/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:indeterminate {
-  background-color: #1c1b22;
-  border: 1px solid #696968;
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    background-color: #1c1b22;
+    border: 1px solid #696968;
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QCheckBox::indicator:indeterminate:disabled {
-  background-color: #2b2b2b;
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    background-color: #2b2b2b;
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QCheckBox::indicator:indeterminate:hover, QCheckBox::indicator:indeterminate:pressed {
-  background-color: @ThemeAccentColor1; /* QRadioButton has the same color */
+    background-color: @ThemeAccentColor1; /* QRadioButton has the same color */
 }
 
 /* QGroupBox --------------------------------------------------------------
@@ -306,58 +306,58 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qgroupbox
 
 --------------------------------------------------------------------------- */
 QGroupBox {
-  font-weight: bold;
-  border: 1px solid #696968;
-  border-radius: 1.9px;
-  padding: 2px;
-  margin-top: 10px;
-  margin-bottom: 4px;
+    font-weight: bold;
+    border: 1px solid #696968;
+    border-radius: 1.9px;
+    padding: 2px;
+    margin-top: 10px;
+    margin-bottom: 4px;
 }
 
 QGroupBox::title {
-  subcontrol-origin: margin;
-  subcontrol-position: top left;
-  left: 4px;
-  padding-left: 2px;
-  padding-right: 4px;
-  padding-top: 6px;
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 4px;
+    padding-left: 2px;
+    padding-right: 4px;
+    padding-top: 6px;
 }
 
 QGroupBox::indicator {
-  color: white;
-  background-color: #3c3c3c;
-  border: 1px solid #696968;
-  width: 12px;
-  height: 12px;
-  border-radius:1px;
+    color: white;
+    background-color: #3c3c3c;
+    border: 1px solid #696968;
+    width: 12px;
+    height: 12px;
+    border-radius:1px;
 }
 
 QGroupBox::indicator:unchecked {
-  background-color: #696968;
-  border: 1px solid #696968;
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    background-color: #696968;
+    border: 1px solid #696968;
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QGroupBox::indicator:unchecked:hover, QGroupBox::indicator:unchecked:focus, QGroupBox::indicator:unchecked:pressed {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QGroupBox::indicator:unchecked:disabled {
-  background-color: #1c1b22;
-  border: 1px solid #696968;
+    background-color: #1c1b22;
+    border: 1px solid #696968;
 }
 
 QGroupBox::indicator:checked {
-  border: none;
-  image:url(qss:images_dark-light/checkbox_light.svg);
+    border: none;
+    image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
 QGroupBox::indicator:checked:hover, QGroupBox::indicator:checked:focus, QGroupBox::indicator:checked:pressed {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QGroupBox::indicator:checked:disabled {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 /* QRadioButton -----------------------------------------------------------
@@ -366,72 +366,72 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qradiobutton
 
 --------------------------------------------------------------------------- */
 QRadioButton {
-  background-color: transparent;
-  color: White;
-  border: none;
-  spacing: 4px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  outline: none;
+    background-color: transparent;
+    color: White;
+    border: none;
+    spacing: 4px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    outline: none;
 }
 
 QRadioButton:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QRadioButton:disabled {
-  background-color: #696968;
-  color: #353535;
+    background-color: #696968;
+    color: #353535;
 }
 
 QRadioButton QWidget {
-  background-color: transparent;
-  color: White;
-  spacing: 0px;
-  padding: 0px;
-  outline: none;
-  border: none;
+    background-color: transparent;
+    color: White;
+    spacing: 0px;
+    padding: 0px;
+    outline: none;
+    border: none;
 }
 
 QRadioButton::indicator {
-  background-color: #3c3c3c;
-  border: 1px solid #696968;
-  border-radius: 6px;
-  margin-left: 0px;
-  height: 11px;
-  width: 11px;
+    background-color: #3c3c3c;
+    border: 1px solid #696968;
+    border-radius: 6px;
+    margin-left: 0px;
+    height: 11px;
+    width: 11px;
 }
 
-QRadioButton::indicator:unchecked {
-  /*image:url(qss:images_dark-light/radiobutton_light.svg);*/
-}
+/* QRadioButton::indicator:unchecked {
+    image:url(qss:images_dark-light/radiobutton_light.svg);
+}*/
 
 QRadioButton::indicator:unchecked:hover, QRadioButton::indicator:unchecked:pressed {
-  background-color: @ThemeAccentColor1;
-  border: 1px solid @ThemeAccentColor1;
-  border-radius: 6px;
+    background-color: @ThemeAccentColor1;
+    border: 1px solid @ThemeAccentColor1;
+    border-radius: 6px;
 }
 
 QRadioButton::indicator:unchecked:disabled {
-  /*image:url(qss:images_dark-light/radiobutton_dark.svg);*/
-  border: 1px solid #696968;
+    /*image:url(qss:images_dark-light/radiobutton_dark.svg);*/
+    border: 1px solid #696968;
 }
 
 QRadioButton::indicator:checked {
-  image:url(qss:images_dark-light/radiobutton_light.svg);
+    image:url(qss:images_dark-light/radiobutton_light.svg);
 }
 
 QRadioButton::indicator:checked:hover, QRadioButton::indicator:checked:pressed {
-  background-color: @ThemeAccentColor1;
-  border: 1px solid @ThemeAccentColor1;
-  border-radius: 6px;
-  image:url(qss:images_dark-light/radiobutton_light.svg);
+    background-color: @ThemeAccentColor1;
+    border: 1px solid @ThemeAccentColor1;
+    border-radius: 6px;
+    image:url(qss:images_dark-light/radiobutton_light.svg);
 }
 
 QRadioButton::indicator:checked:disabled {
-  outline: none;
-  background-color: #696968;
-  image:url(qss:images_dark-light/radiobutton_dark.svg);
+    outline: none;
+    background-color: #696968;
+    image:url(qss:images_dark-light/radiobutton_dark.svg);
 }
 
 /* QMenuBar ---------------------------------------------------------------
@@ -440,40 +440,40 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qmenubar
 
 --------------------------------------------------------------------------- */
 QMenuBar {
-  background-color: #161616;
-  /*padding: 1px;
-  border: 0px solid rgba(0,0,0,140);*/
-  color: White;
-  selection-background-color: @ThemeAccentColor1;
+    background-color: #161616;
+    /*padding: 1px;
+    border: 0px solid rgba(0,0,0,140);*/
+    color: White;
+    selection-background-color: @ThemeAccentColor1;
 }
 
 QMenuBar:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QMenuBar::item {
-  background: transparent;
-   /*padding-left:5px;
-  padding-right: 5px;
-  padding-bottom: 1px;
-  padding-top: 1px;*/
+    background: transparent;
+    /*padding-left:5px;
+    padding-right: 5px;
+    padding-bottom: 1px;
+    padding-top: 1px;*/
 }
 
 QMenuBar::item:selected {
-  background: transparent;
-  border: 0px solid #696968;
-  background-color: @ThemeAccentColor1;
+    background: transparent;
+    border: 0px solid #696968;
+    background-color: @ThemeAccentColor1;
 }
 
 QMenuBar::item:pressed {
-  /*padding: 2px;
-  padding-left: 10px;
-  padding-right: 10px;*/
-  border: 0px solid #696968;
-  background-color: @ThemeAccentColor1;
-  color: White;
- /*margin-bottom: 0px;
-  padding-bottom: 0px;*/
+    /*padding: 2px;
+    padding-left: 10px;
+    padding-right: 10px;*/
+    border: 0px solid #696968;
+    background-color: @ThemeAccentColor1;
+    color: White;
+    /*margin-bottom: 0px;
+    padding-bottom: 0px;*/
 }
 
 /* QMenu ------------------------------------------------------------------
@@ -482,138 +482,138 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qmenu
 
 --------------------------------------------------------------------------- */
 QMenu {
-  border-bottom: 2px rgba(0,0,0,140);
-  border-right: 2px rgba(0,0,0,140);
-  color: White;
-  margin: 0px;
-  background-color: #161616;
-  selection-background-color: @ThemeAccentColor1;
+    border-bottom: 2px rgba(0,0,0,140);
+    border-right: 2px rgba(0,0,0,140);
+    color: White;
+    margin: 0px;
+    background-color: #161616;
+    selection-background-color: @ThemeAccentColor1;
 }
 
 QMenu::separator {
-  height: 2px;
-  background-color: #3c3c3c;
-  margin-left: 30%;
-  margin-right: 30%;
+    height: 2px;
+    background-color: #3c3c3c;
+    margin-left: 30%;
+    margin-right: 30%;
 }
 
 QMenu::item {
-  background-color: transparent;
-  padding: 2px 2px; /* make room for icon at left */
-  /* Reserve space for selection border */
-  border: 0px transparent #696968;
+    background-color: transparent;
+    padding: 2px 2px; /* make room for icon at left */
+    /* Reserve space for selection border */
+    border: 0px transparent #696968;
 }
 
 QMenu::item:selected {
-  color: White;
-  background-color: @ThemeAccentColor1;
+    color: White;
+    background-color: @ThemeAccentColor1;
 }
 
 QMenu::item:pressed {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QMenu::icon {
-  margin-left: 5px;
-  width: 14px;
-  height: 14px;
+    margin-left: 5px;
+    width: 14px;
+    height: 14px;
 }
 
 QMenu::indicator {
-  margin-left: 2px;
-  margin-right: 2px;
-  padding: 0px;
-  width: 12px;
-  height: 12px;
-  /* non-exclusive indicator = check box style indicator (see QActionGroup::setExclusive) */
-  /* exclusive indicator = radio button style indicator (see QActionGroup::setExclusive) */
+    margin-left: 2px;
+    margin-right: 2px;
+    padding: 0px;
+    width: 12px;
+    height: 12px;
+    /* non-exclusive indicator = check box style indicator (see QActionGroup::setExclusive) */
+    /* exclusive indicator = radio button style indicator (see QActionGroup::setExclusive) */
 }
 
 QMenu::icon:checked { /* appearance of a 'checked' icon */
-  background: @ThemeAccentColor2;
-  margin-left: -5px;
-  border: 5px solid @ThemeAccentColor2;
-  position: absolute;
-  border-radius: 0px;
+    background: @ThemeAccentColor2;
+    margin-left: -5px;
+    border: 5px solid @ThemeAccentColor2;
+    position: absolute;
+    border-radius: 0px;
 }
 QMenu::indicator:non-exclusive:unchecked {
-  image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QMenu::indicator:non-exclusive:unchecked:hover, QMenu::indicator:non-exclusive:unchecked:focus, QMenu::indicator:non-exclusive:unchecked:pressed {
-  border: none;
-  background: @ThemeAccentColor1;
+    border: none;
+    background: @ThemeAccentColor1;
 }
 
 QMenu::indicator:non-exclusive:unchecked:disabled {
-  image: url(qss:images_dark-light/checkbox_unchecked_disabled.svg);
+    image: url(qss:images_dark-light/checkbox_unchecked_disabled.svg);
 }
 
 QMenu::indicator:non-exclusive:checked {
-  image:url(qss:images_dark-light/checkbox_light.svg);
+    image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
 QMenu::indicator:non-exclusive:checked:hover, QMenu::indicator:non-exclusive:checked:focus, QMenu::indicator:non-exclusive:checked:pressed {
-  border: none;
-  background: @ThemeAccentColor1;
+    border: none;
+    background: @ThemeAccentColor1;
 }
 
 QMenu::indicator:non-exclusive:checked:disabled {
-  image:url(qss:images_dark-light/checkbox_checked_disabled.svg);
+    image:url(qss:images_dark-light/checkbox_checked_disabled.svg);
 }
 
 QMenu::indicator:non-exclusive:indeterminate {
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QMenu::indicator:non-exclusive:indeterminate:disabled {
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QMenu::indicator:non-exclusive:indeterminate:focus, QMenu::indicator:non-exclusive:indeterminate:hover, QMenu::indicator:non-exclusive:indeterminate:pressed {
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QMenu::indicator:exclusive:unchecked {
-  image: url(qss:images_dark-light/transparent.svg);
+    image: url(qss:images_dark-light/transparent.svg);
 }
 
 QMenu::indicator:exclusive:unchecked:hover, QMenu::indicator:exclusive:unchecked:focus, QMenu::indicator:exclusive:unchecked:pressed {
-  border: none;
-  outline: none;
-  background: @ThemeAccentColor1;
-  image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    border: none;
+    outline: none;
+    background: @ThemeAccentColor1;
+    image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QMenu::indicator:exclusive:unchecked:disabled {
-  image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QMenu::indicator:exclusive:checked {
-  border: none;
-  outline: none;
-  image: url(qss:images_dark-light/radiobutton_light.svg);
+    border: none;
+    outline: none;
+    image: url(qss:images_dark-light/radiobutton_light.svg);
 }
 
 QMenu::indicator:exclusive:checked:hover, QMenu::indicator:exclusive:checked:focus, QMenu::indicator:exclusive:checked:pressed {
-  border: none;
-  outline: none;
-  background: @ThemeAccentColor1;
-  image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
+    border: none;
+    outline: none;
+    background: @ThemeAccentColor1;
+    image: url(qss:images_dark-light/checkbox_unchecked_light.svg);
 }
 
 QMenu::indicator:exclusive:checked:disabled {
-  outline: none;
-  image: url(qss:images_dark-light/radiobutton_light.svg);
+    outline: none;
+    image: url(qss:images_dark-light/radiobutton_light.svg);
 }
 
 QMenu::right-arrow {
-  margin: 5px;
-  padding-left: 12px;
-  image:url(qss:images_dark-light/right_arrow_lighter.svg);
-  height: 12px;
-  width: 12px;
-  background-color: transparent;
+    margin: 5px;
+    padding-left: 12px;
+    image:url(qss:images_dark-light/right_arrow_lighter.svg);
+    height: 12px;
+    width: 12px;
+    background-color: transparent;
 }
 
 /* QAbstractItemView ------------------------------------------------------
@@ -622,14 +622,14 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qcombobox
 
 --------------------------------------------------------------------------- */
 QAbstractItemView {
-  alternate-background-color: #5b5b5b;
-  color: White;
-  border: 1px solid #696968;
-  border-radius: 2px;
+    alternate-background-color: #5b5b5b;
+    color: White;
+    border: 1px solid #696968;
+    border-radius: 2px;
 }
 
 QAbstractItemView QLineEdit {
-  padding: 2px;
+    padding: 2px;
 }
 
 /* QAbstractScrollArea ----------------------------------------------------
@@ -638,17 +638,17 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qabstractscrollarea
 
 --------------------------------------------------------------------------- */
 QAbstractScrollArea {
-  background-color: transparent;
-  border: 0px solid #696968;
-  border-radius: 0px;
-  /* fix #159 */
-  padding: 0px;
-  /* remove min-height to fix #244 */
-  color: White;
+    background-color: transparent;
+    border: 0px solid #696968;
+    border-radius: 0px;
+    /* fix #159 */
+    padding: 0px;
+    /* remove min-height to fix #244 */
+    color: White;
 }
 
 QAbstractScrollArea:disabled {
-  color: #353535;
+    color: #353535;
 }
 
 /* QScrollArea ------------------------------------------------------------
@@ -656,7 +656,7 @@ QAbstractScrollArea:disabled {
 ---------------------------------------------------------------------------
 text input field disabled!!!!*/
 QScrollArea QWidget:disabled {
-  background-color: #2b2b2b;
+    background-color: #2b2b2b;
 }
 
 /* QScrollBar -------------------------------------------------------------
@@ -665,139 +665,139 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qscrollbar
 
 --------------------------------------------------------------------------- */
 QScrollBar:horizontal {
-  height: 16px;
-  margin: 2px 16px 2px 16px;
-  border: 0px solid #696968;
-  border-radius: 1.9px;
-  background-color: #2b2b2b;
+    height: 16px;
+    margin: 2px 16px 2px 16px;
+    border: 0px solid #696968;
+    border-radius: 1.9px;
+    background-color: #2b2b2b;
 }
 
 QScrollBar:vertical {
-  background-color: #2b2b2b;
-  width: 16px;
-  margin: 16px 2px 16px 2px;
-  border: 0px solid #696968;
-  border-radius: 1.9px;
+    background-color: #2b2b2b;
+    width: 16px;
+    margin: 16px 2px 16px 2px;
+    border: 0px solid #696968;
+    border-radius: 1.9px;
 }
 
 QScrollBar::handle:horizontal {
-  background-color: #696969;
-  border: 1px solid #2b2b2b;
-  border-radius: 1.9px;
-  min-width: 8px;
+    background-color: #696969;
+    border: 1px solid #2b2b2b;
+    border-radius: 1.9px;
+    min-width: 8px;
 }
 
 QScrollBar::handle:horizontal:hover {
-  background-color: @ThemeAccentColor1;
-  border: #696968;
-  border-radius: 1.9px;
-  min-width: 8px;
+    background-color: @ThemeAccentColor1;
+    border: #696968;
+    border-radius: 1.9px;
+    min-width: 8px;
 }
 
 QScrollBar::handle:horizontal:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QScrollBar::handle:vertical {
-  background-color: #696969;
-  border: 1px solid #696968;
-  min-height: 8px;
-  border-radius: 1.9px;
+    background-color: #696969;
+    border: 1px solid #696968;
+    min-height: 8px;
+    border-radius: 1.9px;
 }
 
 QScrollBar::handle:vertical:hover {
-  background-color: @ThemeAccentColor1;
-  border: #696968;
-  border-radius: 1.9px;
-  min-height: 8px;
+    background-color: @ThemeAccentColor1;
+    border: #696968;
+    border-radius: 1.9px;
+    min-height: 8px;
 }
 
 QScrollBar::handle:vertical:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QScrollBar::add-line:horizontal {
-  border-image: url(qss:images_dark-light/right_arrow_light.svg);
-  height: 9px;
-  width: 5px;
-  subcontrol-position: right;
-  subcontrol-origin: margin;
+    border-image: url(qss:images_dark-light/right_arrow_light.svg);
+    height: 9px;
+    width: 5px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::add-line:horizontal:hover, QScrollBar::add-line:horizontal:on {
-  border-image: url(qss:images_dark-light/right_arrow_lighter.svg);
-
-  height: 9px;
-  width: 5px;
-  subcontrol-position: right;
-  subcontrol-origin: margin;
+    border-image: url(qss:images_dark-light/right_arrow_lighter.svg);
+    height: 9px;
+    width: 5px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::add-line:vertical {
-  border-image: url(qss:images_dark-light/down_arrow_light.svg);
-  height: 5px;
-  width: 9px;
-  subcontrol-position: bottom;
-  subcontrol-origin: margin;
+    border-image: url(qss:images_dark-light/down_arrow_light.svg);
+    height: 5px;
+    width: 9px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::add-line:vertical:hover, QScrollBar::add-line:vertical:on {
-  border-image: url(qss:images_dark-light/down_arrow_lighter.svg);
-  height: 5px;
-  width: 9px;
-  subcontrol-position: bottom;
-  subcontrol-origin: margin;
+    border-image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    height: 5px;
+    width: 9px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::sub-line:horizontal {
-  margin: 0px 0px 0px 0px;
-  border-image: url(qss:images_dark-light/left_arrow_light.svg);
-  height: 9px;
-  width: 5px;
-  subcontrol-position: left;
-  subcontrol-origin: margin;
+    margin: 0px 0px 0px 0px;
+    border-image: url(qss:images_dark-light/left_arrow_light.svg);
+    height: 9px;
+    width: 5px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::sub-line:horizontal:hover, QScrollBar::sub-line:horizontal:on {
-  border-image: url(qss:images_dark-light/left_arrow_lighter.svg);
-  height: 9px;
-  width: 5px;
-  subcontrol-position: left;
-  subcontrol-origin: margin;
+    border-image: url(qss:images_dark-light/left_arrow_lighter.svg);
+    height: 9px;
+    width: 5px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::sub-line:vertical {
-  margin: 0px 0px 0px 0px;
-  border-image: url(qss:images_dark-light/up_arrow_light.svg);
-  height: 5px;
-  width: 9px;
-  subcontrol-position: top;
-  subcontrol-origin: margin;
+    margin: 0px 0px 0px 0px;
+    border-image: url(qss:images_dark-light/up_arrow_light.svg);
+    height: 5px;
+    width: 9px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::sub-line:vertical:hover, QScrollBar::sub-line:vertical:on {
-  border-image: url(qss:images_dark-light/up_arrow_lighter.svg);
-  height: 5px;
-  width: 9px;
-  subcontrol-position: top;
-  subcontrol-origin: margin;
+    border-image: url(qss:images_dark-light/up_arrow_lighter.svg);
+    height: 5px;
+    width: 9px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
 }
 
 QScrollBar::up-arrow:horizontal, QScrollBar::down-arrow:horizontal {
-  background: none;
+    background: none;
 }
 
 QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
-  background: none;
+    background: none;
 }
 
 QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {
-  background: none;
+    background: none;
 }
 
 QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
-  background: none;
+    background: none;
 }
+
 
 /* QTextEdit --------------------------------------------------------------
 
@@ -807,38 +807,38 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-specific-widgets
 report view
 --------------------------------------------------------------------------- */
 QTextEdit {
-  background-color: #2b2b2b;
-  color: White;
-  border-radius: 1.9px;
-  border: 0px solid #696968;
+    background-color: #2b2b2b;
+    color: White;
+    border-radius: 1.9px;
+    border: 0px solid #696968;
 }
 
 QTextEdit:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QTextEdit:selected {
-  background: #346792;
-  color: white;
+    background: #346792;
+    color: white;
 }
 
 /* QPlainTextEdit ---------------------------------------------------------
 Python
 --------------------------------------------------------------------------- */
 QPlainTextEdit {
-  background-color: #3c3c3c;
-  color: White;
-  border-radius: 1.9px;
-  border: 0px solid #696968;
+    background-color: #3c3c3c;
+    color: White;
+    border-radius: 1.9px;
+    border: 0px solid #696968;
 }
 
 QPlainTextEdit:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QPlainTextEdit:selected {
-  background: @ThemeAccentColor1;
-  color: White;
+    background: @ThemeAccentColor1;
+    color: White;
 }
 
 /* QSizeGrip --------------------------------------------------------------
@@ -847,18 +847,18 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qsizegrip
 
 --------------------------------------------------------------------------- */
 QSizeGrip {
-  background: transparent;
-  width: 12px;
-  height: 12px;
-  image:url(qss:images_dark-light/sizegrip_light.svg);
+    background: transparent;
+    width: 12px;
+    height: 12px;
+    image:url(qss:images_dark-light/sizegrip_light.svg);
 }
 
 /* QStackedWidget ---------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QStackedWidget {
-  padding: 0px;
-  border: 0px solid #696968;
+    padding: 0px;
+    border: 0px solid #696968;
 }
 
 /* QToolBar ---------------------------------------------------------------
@@ -867,66 +867,68 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbar
 
 --------------------------------------------------------------------------- */
 QToolBar {
-  background-color: #2b2b2b;
-  border-bottom: 0px solid rgba(0,0,0,120);
-  padding: 1px;
-  font-weight: bold;
-  spacing: 1px;
+    background-color: #2b2b2b;
+    border-bottom: 0px solid rgba(0,0,0,120);
+    padding: 1px;
+    font-weight: bold;
+    spacing: 1px;
 }
 
 QToolBar:disabled {
-  /* Fixes #272 */
-  background-color: #2b2b2b;
+    /* Fixes #272 */
+    background-color: #2b2b2b;
 }
 
 QToolBar::handle:horizontal {
-  width: 8px;
-  margin: 3px 3px;
-  background-position: top right;
-  background-repeat: repeat-y;
-  background-image: url(qss:images_dark-light/Hmovetoolbar_light.svg);
+    width: 8px;
+    margin: 3px 3px;
+    background-position: top right;
+    background-repeat: repeat-y;
+    background-image: url(qss:images_dark-light/Hmovetoolbar_light.svg);
 }
 
 QToolBar::handle:vertical {
-  height: 8px;
-  margin: 3px 3px;
-  background-position: left bottom;
-  background-repeat: repeat-x;
-  background-image: url(qss:images_dark-light/Vmovetoolbar_light.svg);
+    height: 8px;
+    margin: 3px 3px;
+    background-position: left bottom;
+    background-repeat: repeat-x;
+    background-image: url(qss:images_dark-light/Vmovetoolbar_light.svg);
 }
 
 QToolBar::separator:horizontal {
-  width: 2px;
-  margin: 4px 4px;
-  background-color: transparent;
+    width: 2px;
+    margin: 4px 4px;
+    background-color: transparent;
 }
 
 QToolBar::separator:vertical {
-  height: 2px;
-  margin: 4px 4px;
-  background-color: transparent;
+    height: 2px;
+    margin: 4px 4px;
+    background-color: transparent;
 }
 
 /*The "show more" button  (it can also be stylable with "QToolBarExtension"  icon is not working Qproperty works but breaks when you move the toolbar see also */
 QToolButton#qt_toolbar_ext_button {
-margin: 0px;
-padding: 0px;
-background-color: #696969;
-/*background-image: url(qss:images_dark-light/more_light.svg);*/
-background-repeat: none;
-background-position: center center;
+    margin: 0px;
+    padding: 0px;
+    background-color: #696969;
+    /*background-image: url(qss:images_dark-light/more_light.svg);*/
+    background-repeat: none;
+    background-position: center center;
 }
 
 QToolButton#qt_toolbar_ext_button:hover {
-/*background-image: url(qss:images_dark-light/more_light.svg);*/
-background-color: @ThemeAccentColor1;
+    /*background-image: url(qss:images_dark-light/more_light.svg);*/
+    background-color: @ThemeAccentColor1;
 }
 
 QToolButton#qt_toolbar_ext_button:on {
-/*background-image: url(qss:images_dark-light/more_light.svg);*/
-border-color: #696968;
-background-color: @ThemeAccentColor1;
+    /*background-image: url(qss:images_dark-light/more_light.svg);*/
+    border-color: #696968;
+    background-color: @ThemeAccentColor1;
 }
+
+
 
 
 /* QAbstractSpinBox -------------------------------------------------------
@@ -934,80 +936,81 @@ background-color: @ThemeAccentColor1;
 --------------------------------------------------------------------------- */
 QAbstractSpinBox,
 QSpinBox {
-  background-color: #1c1b22;
-  border: 1px solid transparent;
-  color: White;
-  /* This fixes 103, 111 */
- /* padding-top: 0px;
-  /* This fixes 103, 111 */
-  /*padding-bottom: 0px;
-  /*padding-left: 4px;
-  /*padding-right: 4px;
-  border-radius: 1.9px;*/
-  min-height: 1.7em;
-  /* min-width: 5px; removed to fix 109 */
+    background-color: #1c1b22;
+    border: 1px solid transparent;
+    color: White;
+    /* This fixes 103, 111 */
+    /* padding-top: 0px;
+    /* This fixes 103, 111 */
+    /*padding-bottom: 0px;
+    /*padding-left: 4px;
+    /*padding-right: 4px;
+    border-radius: 1.9px;*/
+    min-height: 1.7em;
+    /* min-width: 5px; removed to fix 109 */
 }
 
 QAbstractSpinBox:up-button {
-  background-color: #696968;
-  subcontrol-origin: border;
-  subcontrol-position: top right;
-  border-left: 1px solid transparent;
-  border-bottom: 1px solid #1c1b22;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  /*margin: 1px;*/
-  /*width: 12px;
-  /*margin-bottom: -1px;*/
+    background-color: #696968;
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    border-left: 1px solid transparent;
+    border-bottom: 1px solid #1c1b22;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    /*margin: 1px;*/
+    /*width: 12px;
+    /*margin-bottom: -1px;*/
 }
 
 QAbstractSpinBox::up-arrow, QAbstractSpinBox::up-arrow:disabled, QAbstractSpinBox::up-arrow:off {
-  image: url(qss:images_dark-light/up_arrow_disabled_light.svg);
- /* height: 8px;
-  width: 8px;*/
+    image: url(qss:images_dark-light/up_arrow_disabled_light.svg);
+    /* height: 8px;
+    width: 8px;*/
 }
 
 QAbstractSpinBox::up-arrow:hover {
-  /*background-color: @ThemeAccentColor1;*/
-  image: url(qss:images_dark-light/up_arrow_lighter.svg);
+    /*background-color: @ThemeAccentColor1;*/
+    image: url(qss:images_dark-light/up_arrow_lighter.svg);
 }
 
 QAbstractSpinBox:down-button {
-  background-color: #696968;
-  subcontrol-origin: border;
-  subcontrol-position: bottom right;
-  border-left: 1px solid #696968;
-  border-top: 1px solid #696968;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  /*margin: 1px;*/
-  /*width: 12px;
-  /*margin-top: -1px;*/
+    background-color: #696968;
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    border-left: 1px solid #696968;
+    border-top: 1px solid #696968;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    /*margin: 1px;*/
+    /*width: 12px;
+    /*margin-top: -1px;*/
 }
 
 QAbstractSpinBox::down-arrow, QAbstractSpinBox::down-arrow:disabled, QAbstractSpinBox::down-arrow:off {
-  image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
-  /*height: 8px;
-  width: 8px;*/
+    image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
+    /*height: 8px;
+    width: 8px;*/
 }
 
 QAbstractSpinBox::down-arrow:hover {
-  image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    image: url(qss:images_dark-light/down_arrow_lighter.svg);
 }
 
-QAbstractSpinBox:hover {
+/* QAbstractSpinBox:hover {
   /*border: 1px solid @ThemeAccentColor1;
-  color: White;*/
-}
+  color: White;
+}*/
 
 QAbstractSpinBox:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QAbstractSpinBox:selected {
-  background: @ThemeAccentColor2;
-  /*color: White;*/
+    background: @ThemeAccentColor2;
+    /*color: White;*/
 }
+
 
 /* ------------------------------------------------------------------------ */
 /* DISPLAYS --------------------------------------------------------------- */
@@ -1018,21 +1021,21 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qframe
 
 --------------------------------------------------------------------------- */
 QLabel {
-  background-color: transparent;
-  border: 0px solid #696968;
-  padding: 2px;
-  margin: 0px;
-  color: White;
+    background-color: transparent;
+    border: 0px solid #696968;
+    padding: 2px;
+    margin: 0px;
+    color: White;
 }
 
 QLabel:disabled {
-  background-color: transparent;
-  border: 0px solid #696968;
-  color: #c2c7cb;
+    background-color: transparent;
+    border: 0px solid #696968;
+    color: #c2c7cb;
 }
 
 QLabel[haslink="true"] {
-  color: orange;
+    color: orange;
 }
 
 
@@ -1042,68 +1045,68 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qabstractscrollarea
 
 --------------------------------------------------------------------------- */
 QTextBrowser {
-  background-color: #1c1b22;
-  border: 1px solid #696968;
-  color: White;
-  border-radius: 1.9px;
+    background-color: #1c1b22;
+    border: 1px solid #696968;
+    color: White;
+    border-radius: 1.9px;
 }
 
 QTextBrowser:disabled {
-  background-color: #2b2b2b;
-  border: 1px solid #696968;
-  color: #c2c7cb;
-  border-radius: 1.9px;
+    background-color: #2b2b2b;
+    border: 1px solid #696968;
+    color: #c2c7cb;
+    border-radius: 1.9px;
 }
 
 QTextBrowser:hover, QTextBrowser:!hover, QTextBrowser:selected, QTextBrowser:pressed {
-  border: 1px solid @ThemeAccentColor1;
+    border: 1px solid @ThemeAccentColor1;
 }
 
 /* QGraphicsView ----------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QGraphicsView {
-  background-color: transparent;
-  border: 0px solid @ThemeAccentColor1;
-  color: White;
-  border-radius: 0px;
+    background-color: transparent;
+    border: 0px solid @ThemeAccentColor1;
+    color: White;
+    border-radius: 0px;
 }
 
 QGraphicsView:disabled {
-  background-color: #1c1b22;
-  border: 0px solid #696968;
-  color: #c2c7cb;
-  border-radius: 0px;
+    background-color: #1c1b22;
+    border: 0px solid #696968;
+    color: #c2c7cb;
+    border-radius: 0px;
 }
 
 QGraphicsView:hover, QGraphicsView:!hover, QGraphicsView:selected, QGraphicsView:pressed {
-  border: 0px solid #ff00f7;
+    border: 0px solid #ff00f7;
 }
 
 /* QCalendarWidget --------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QCalendarWidget {
-  border: 1px solid #696968;
-  border-radius: 1.9px;
+    border: 1px solid #696968;
+    border-radius: 1.9px;
 }
 
 QCalendarWidget:disabled {
-  background-color: #353535;
-  color: #c2c7cb;
+    background-color: #353535;
+    color: #c2c7cb;
 }
 
 /* QLCDNumber -------------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QLCDNumber {
-  background-color: #1aff00;
-  color: White;
+    background-color: #1aff00;
+    color: White;
 }
 
 QLCDNumber:disabled {
-  background-color: #2b2b2b;
-  color: #c2c7cb;
+    background-color: #2b2b2b;
+    color: #c2c7cb;
 }
 
 /* QProgressBar -----------------------------------------------------------
@@ -1112,31 +1115,31 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qprogressbar
 
 --------------------------------------------------------------------------- */
 QProgressBar {
-  background-color: #c2c7cb;
-  border: 1px solid #696968;
-  color: White;
-  border-radius: 1.9px;
-  text-align: center;
+    background-color: #c2c7cb;
+    border: 1px solid #696968;
+    color: White;
+    border-radius: 1.9px;
+    text-align: center;
 }
 
 QProgressBar:disabled {
-  background-color: #161616;
-  border: 1px solid #696968;
-  color: #696969;
-  border-radius: 1.9px;
-  text-align: center;
+    background-color: #161616;
+    border: 1px solid #696968;
+    color: #696969;
+    border-radius: 1.9px;
+    text-align: center;
 }
 
 QProgressBar::chunk {
-  background-color: @ThemeAccentColor1;
-  color: #2b2b2b;
-  border-radius: 1.9px;
+    background-color: @ThemeAccentColor1;
+    color: #2b2b2b;
+    border-radius: 1.9px;
 }
 
 QProgressBar::chunk:disabled {
-  background-color: #161616;
-  color: #696968;
-  border-radius: 1.9px;
+    background-color: #161616;
+    color: #696968;
+    border-radius: 1.9px;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -1148,64 +1151,72 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qpushbutton
 
 --------------------------------------------------------------------------- */
 QPushButton {
-  background-color: #696969;
-  color: White;
-  border-radius: 2px;
-  padding: 2px;
-  outline: none;
-  border: none;
+    background-color: #696969;
+    color: White;
+    border-radius: 2px;
+    padding: 2px;
+    outline: none;
+    border: none;
+}
+
+#CreateNewRow > QPushButton { /* linked to https://github.com/FreeCAD/FreeCAD/pull/15356
+    /* Reset min width to default */
+    min-width: -1;
+    min-height: 50px;
 }
 
 QPushButton:disabled {
-  background-color: #2b2b2b;
-  color: #c2c7cb;
-  border-radius: 2px;
-  padding: 2px;
+    background-color: #2b2b2b;
+    color: #c2c7cb;
+    border-radius: 2px;
+    padding: 2px;
 }
 
 QPushButton:checked {
-  background-color: @ThemeAccentColor1;
-  border-radius: 2px;
-  padding: 2px;
-  outline: none;
+    background-color: @ThemeAccentColor1;
+    border-radius: 2px;
+    padding: 2px;
+    outline: none;
 }
 
 QPushButton:checked:disabled {
-  background-color: @ThemeAccentColor1;
-  color: #3c3c3c;
-  border-radius: 2px;
-  padding: 2px;
-  outline: none;
+    background-color: @ThemeAccentColor1;
+    color: #3c3c3c;
+    border-radius: 2px;
+    padding: 2px;
+    outline: none;
 }
 
 QPushButton:checked:selected {
-  background: @ThemeAccentColor1;
+    background: @ThemeAccentColor1;
 }
 
 QPushButton:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
-  color: White;
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+    color: White;
 }
 
 QPushButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:selected {
-  background: @ThemeAccentColor2;
-  color: White;
+    background: @ThemeAccentColor2;
+    color: White;
 }
 
 QPushButton::menu-indicator {
-  subcontrol-origin: padding;
-  subcontrol-position: bottom right;
-  bottom: 4px;
+    subcontrol-origin: padding;
+    subcontrol-position: bottom right;
+    bottom: 4px;
 }
 
 QDialogButtonBox QPushButton {
-  /* Issue # 194 # 248 - Special case of QPushButton inside dialogs, for better UI */
-  min-width: 80px;
+    /* Issue # 194 # 248 - Special case of QPushButton inside dialogs, for better UI */
+    min-width: 80px;
 }
+
+
 
 /* QToolButton ------------------------------------------------------------
 
@@ -1213,160 +1224,165 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbutton
 
 --------------------------------------------------------------------------- */
 QToolButton {
-  background-color: transparent;
-  color: White;
-  border-radius: 1px;
-  padding: 0px;
-  outline: none;
-  border: none;
-  /* The subcontrols below are used only in the DelayedPopup mode */
-  /* The subcontrols below are used only in the MenuButtonPopup mode */
-  /* The subcontrol below is used only in the InstantPopup or DelayedPopup mode */
+    background-color: transparent;
+    color: White;
+    border-radius: 1px;
+    padding: 0px;
+    outline: none;
+    border: none;
+    /* The subcontrols below are used only in the DelayedPopup mode */
+    /* The subcontrols below are used only in the MenuButtonPopup mode */
+    /* The subcontrol below is used only in the InstantPopup or DelayedPopup mode */
 }
 
 QToolButton:disabled {
-  background-color: rgba(0, 0, 0, 0.065);
-  color: transparent;
-  border-radius: 1px;
-  padding: 0px;
-  opacity: 1.0;
+    background-color: rgba(0, 0, 0, 0.065);
+    color: transparent;
+    border-radius: 1px;
+    padding: 0px;
+    opacity: 1.0;
 }
 
 QToolButton:checked {
-  background-color: @ThemeAccentColor1;
-  border-radius: 1.9px;
-  padding: 0px;
-  outline: none;
+    background-color: @ThemeAccentColor1;
+    border-radius: 1.9px;
+    padding: 0px;
+    outline: none;
 }
 
 QToolButton:checked:disabled {
-  background-color: #b65555;
-  color: #c2c7cb;
-  border-radius: 1.9px;
-  padding: 0px;
-  outline: none;
+    background-color: #b65555;
+    color: #c2c7cb;
+    border-radius: 1.9px;
+    padding: 0px;
+    outline: none;
 }
 
 QToolButton:checked:hover {
-  background-color: @ThemeAccentColor1;
-  color: White;
+    background-color: @ThemeAccentColor1;
+    color: White;
 }
 
 QToolButton:checked:pressed {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QToolButton:checked:selected {
-  background: @ThemeAccentColor2;
-  color: White;
+    background: @ThemeAccentColor2;
+    color: White;
 }
 
 QToolButton:hover {
-  background-color: @ThemeAccentColor1;
-  color: White;
+    background-color: @ThemeAccentColor1;
+    color: White;
 }
 
 QToolButton:pressed {
-  background-color: @ThemeAccentColor2;
+    background-color: @ThemeAccentColor2;
 }
 
 QToolButton:selected {
-  background: @ThemeAccentColor1;
-  color: White;
+    background: @ThemeAccentColor1;
+    color: White;
 }
 
 QToolButton[popupMode="0"] {
-  /* Only for DelayedPopup */
-  padding-right: 20px;
+    /* Only for DelayedPopup */
+    padding-right: 20px;
 }
 
 QToolButton[popupMode="1"] {
-  /* Only for MenuButtonPopup */
-  padding-right: 20px;
+    /* Only for MenuButtonPopup */
+    padding-right: 20px;
 }
 QToolButton[popupMode="0"]::menu-button {
-  border: none;
+    border: none;
 }
 
 QToolButton[popupMode="0"]::menu-button:hover {
-  border: none;
-  border-left: 2px solid #fe0000;
-  border-radius: 0px;
+    border: none;
+    border-left: 2px solid #fe0000;
+    border-radius: 0px;
 }
 QToolButton[popupMode="1"]::menu-button {
-  border: none;
+    border: none;
 }
 
 QToolButton[popupMode="1"]::menu-button:hover {
-  border: none;
-  border-left: 2px solid #e5ff00;
-  border-radius: 0px;
+    border: none;
+    border-left: 2px solid #e5ff00;
+    border-radius: 0px;
 }
 
 QToolButton[popupMode="2"] {
-  /* Only for InstantPopup */
-  padding-right: 20px;
+    /* Only for InstantPopup */
+    padding-right: 20px;
 }
 
 QToolButton::menu-button {
-  border-bottom: 0px solid #ffffff;
-  border-radius: 2px;
-  /* 16px width + 4px for border = 20px allocated above */
-  width: 1.6ex;
-  padding: 2px;
-  border-radius: 2px;
-  border: 0px #000000;
+    border-bottom: 0px solid #ffffff;
+    border-radius: 2px;
+    /* 16px width + 4px for border = 20px allocated above */
+    width: 1.6ex;
+    padding: 2px;
+    border-radius: 2px;
+    border: 0px #000000;
 }
 
-QToolButton::menu-button:hover {
- /* background: rgba(0, 0, 0, 0.5);*/
-
+/* QToolButton::menu-button:hover {
+    background: rgba(0, 0, 0, 0.5);
 }
 
 QToolButton::menu-button:checked:hover {
- /* background: rgba(0, 0, 0, 0.5);*/
-}
+    background: rgba(0, 0, 0, 0.5);
+} */
 
 QToolButton::menu-indicator {
-  /* Exclude a shift for better image */
-  subcontrol-position: right bottom;
-  /* Shift it a bit */
+    /* Exclude a shift for better image */
+    subcontrol-position: right bottom;
+    /* Shift it a bit */
 }
 
 QToolButton::menu-arrow {
-  image: url(qss:images_dark-light/more_arrow_light.svg);
-  width: 1.5ex;
-  height: 1.5ex;
-  subcontrol-position: right bottom;
-  background: transparent;
+    image: url(qss:images_dark-light/more_arrow_light.svg);
+    width: 1.5ex;
+    height: 1.5ex;
+    subcontrol-position: right bottom;
+    background: transparent;
 }
+
 QToolButton::menu-arrow:open {
-  subcontrol-position: right bottom;
-  image: url(qss:images_dark-light/more_arrow_light.svg);
-  width: 1.7ex;
-  height: 1.7ex;
+    subcontrol-position: right bottom;
+    image: url(qss:images_dark-light/more_arrow_light.svg);
+    width: 1.7ex;
+    height: 1.7ex;
 }
+
 QToolButton::menu-arrow:hover {
-  image: url(qss:images_dark-light/more_arrow_light.svg);
-  width: 1.7ex;
-  height: 1.7ex;
+    image: url(qss:images_dark-light/more_arrow_light.svg);
+    width: 1.7ex;
+    height: 1.7ex;
 }
+
+
+
+
 
 /* QCommandLinkButton -----------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QCommandLinkButton {
-  background-color: transparent;
-  border: 1px solid #696968;
-  color: White;
-  border-radius: 1.9px;
-  padding: 0px;
-  margin: 0px;
+    background-color: transparent;
+    border: 1px solid #696968;
+    color: White;
+    border-radius: 1.9px;
+    padding: 0px;
+    margin: 0px;
 }
 
 QCommandLinkButton:disabled {
-  background-color: transparent;
-  color: #c2c7cb;
+    background-color: transparent;
+    color: #c2c7cb;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -1378,79 +1394,81 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qcombobox
 
 --------------------------------------------------------------------------- */
 QComboBox {
-  border: 1px solid transparent;
-  background: #1c1b22;
-  border-radius: 2px;
-  selection-background-color: @ThemeAccentColor1;
-  padding-left: 2px;
-  padding-right: 2px;
-  /* padding-right = 36; 4 + 16*2 See scrollbar size */
-  /* changed to 4px to fix #239 */
-  /* Fixes #103, #111 */
-  min-height: 1.5em;
-  /* padding-top: 2px;     removed to fix #132 */
-  /* padding-bottom: 2px;  removed to fix #132 */
-  /* min-width: 75px;      removed to fix #109 */
-  /* Needed to remove indicator - fix #132 */
+    border: 1px solid transparent;
+    background: #1c1b22;
+    border-radius: 2px;
+    selection-background-color: @ThemeAccentColor1;
+    padding-left: 2px;
+    padding-right: 2px;
+    /* padding-right = 36; 4 + 16*2 See scrollbar size */
+    /* changed to 4px to fix #239 */
+    /* Fixes #103, #111 */
+    min-height: 1.5em;
+    /* padding-top: 2px;     removed to fix #132 */
+    /* padding-bottom: 2px;  removed to fix #132 */
+    /* min-width: 75px;      removed to fix #109 */
+    /* Needed to remove indicator - fix #132 */
 }
+
 QComboBox:editable {
-  background: #1c1b22;
+    background: #1c1b22;
 }
+
 QComboBox QAbstractItemView {
-  border: 0px solid #696968;
-  border-radius: 0px;
-  background-color: #1c1b22;
-  selection-background-color: @ThemeAccentColor1;
+    border: 0px solid #696968;
+    border-radius: 0px;
+    background-color: #1c1b22;
+    selection-background-color: @ThemeAccentColor1;
 }
 
 QComboBox QAbstractItemView:hover {
-  background-color:Black;
-  color: White;
+    background-color:Black;
+    color: White;
 }
 
 QComboBox QAbstractItemView:selected {
-  background: @ThemeAccentColor1;
-  color: White;
+    background: @ThemeAccentColor1;
+    color: White;
 }
 
 QComboBox QAbstractItemView:alternate {
-  background: #3c3c3c;
+    background: #3c3c3c;
 }
 
 QComboBox:checked {
-  color: #ffffff;
+    color: #ffffff;
 }
 
 QComboBox:disabled {
-  background-color: #2b2b2b;
-  color: #353535;
+    background-color: #2b2b2b;
+    color: #353535;
 }
 
 QComboBox:hover {
-  /*background-color: @ThemeAccentColor1;*/
-  border: 1px solid @ThemeAccentColor1;
+    /*background-color: @ThemeAccentColor1;*/
+    border: 1px solid @ThemeAccentColor1;
 }
 
 QComboBox:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QComboBox:on {
-  selection-background-color: @ThemeAccentColor2;
+    selection-background-color: @ThemeAccentColor2;
 }
 
 QComboBox::indicator {
-  padding-left: 8px;
-  background-color: transparent;
+    padding-left: 8px;
+    background-color: transparent;
 }
 
 QComboBox::indicator:checked {
-  width: 12px;
-  height: 12px;
-  image: url(qss:images_dark-light/check_light.svg);
+    width: 12px;
+    height: 12px;
+    image: url(qss:images_dark-light/check_light.svg);
 }
 
-QComboBox::item {
+/* QComboBox::item {
   /* Remove to fix #282, #285 and MR #288*/
   /*&:checked {
             font-weight: bold;
@@ -1459,39 +1477,41 @@ QComboBox::item {
         &:selected {
             border: 0px solid transparent;
         }
-        */
 }
-/* Background color of popup-list.*/
+Background color of popup-list.*/
 
 /* Needed to complete the rule set. */
+
 QComboBox::item:alternate {
-  background: #3c3c3c;
+    background: #3c3c3c;
 }
+
 /* Color of the selected list item. */
 QComboBox::item:selected {
-  border: 1px solid @ThemeAccentColor2;
-  background: @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
+    background: @ThemeAccentColor2;
 }
 
 QComboBox::drop-down {
-  subcontrol-origin: padding;
-  background-color: #696969;
-  subcontrol-position: top right;
-  width: 14px;
-  border-left: 1px solid #696968;
+    subcontrol-origin: padding;
+    background-color: #696969;
+    subcontrol-position: top right;
+    width: 14px;
+    border-left: 1px solid #696968;
 }
+
 QComboBox::drop-down:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
-  image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
-  height: 10px;
-  width: 10px;
+    image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
+    height: 10px;
+    width: 10px;
 }
 
 QComboBox::down-arrow:on, QComboBox::down-arrow:hover, QComboBox::down-arrow:focus {
-  image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    image: url(qss:images_dark-light/down_arrow_lighter.svg);
 }
 
 
@@ -1499,21 +1519,19 @@ QComboBox::down-arrow:on, QComboBox::down-arrow:hover, QComboBox::down-arrow:foc
 Tasks panel (custom FreeCAD class)
 ==================================================================================================*/
 Gui--PropertyEditor--PropertyEditor {
-  qproperty-groupTextColor: white;
-  qproperty-groupBackground: #3c3c3c;
-  border: 0px solid #696968;
-
+    qproperty-groupTextColor: white;
+    qproperty-groupBackground: #3c3c3c;
+    border: 0px solid #696968;
 }
 
 /* Action group */
 QFrame[class="panel"] {
-background-color: transparent; /* temporal (transparent background) */
-
+    background-color: transparent; /* temporal (transparent background) */
 }
 
 QSint--ActionGroup {
-padding: 0px; /* if not reset, it might create problems with QPushButtons and other elements */
-margin: 0px; /* if not reset, it might create problems with QPushButtons and other elements */
+    padding: 0px; /* if not reset, it might create problems with QPushButtons and other elements */
+    margin: 0px; /* if not reset, it might create problems with QPushButtons and other elements */
 }
 
 /* Separator line */
@@ -1523,131 +1541,131 @@ QSint--ActionGroup QFrame[height="3"],
 QSint--ActionGroup QFrame[width="1"],
 QSint--ActionGroup QFrame[width="2"],
 QSint--ActionGroup QFrame[width="3"] {
-border-color: rgba(0,0,0,60);
+    border-color: rgba(0,0,0,60);
 }
 
 /* Panel header */
 QSint--ActionGroup QFrame[class="header"] {
-border-top: 1px solid #696968;
-border-left: 1px solid #696968;
-border-right: 1px solid #696968;
-background-color: #696969; /* Task Panel Header background color */
-border-top-left-radius: 3px;
-border-top-right-radius: 3px;
-border-bottom-left-radius: 0px;
-border-bottom-right-radius: 0px;
-margin: 0px;
-padding: 0px;
+    border-top: 1px solid #696968;
+    border-left: 1px solid #696968;
+    border-right: 1px solid #696968;
+    background-color: #696969; /* Task Panel Header background color */
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+    margin: 0px;
+    padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
-color: white; /* Task Panel Header text color */
-text-align: left;
-font-weight: bold;
-border: none;
-margin: 0px;
-padding: 0px;
+    color: white; /* Task Panel Header text color */
+    text-align: left;
+    font-weight: bold;
+    border: none;
+    margin: 0px;
+    padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"] QLabel {
-background-color: transparent;
-background-image: url(qss:images_dark-light/down_arrow_light.svg);
-background-repeat: none;
-background-position: center center;
-padding: 0px;
-margin: 0px;
+    background-color: transparent;
+    background-image: url(qss:images_dark-light/down_arrow_light.svg);
+    background-repeat: none;
+    background-position: center center;
+    padding: 0px;
+    margin: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"] QLabel:hover {
-background-color: transparent;
-background-image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    background-color: transparent;
+    background-image: url(qss:images_dark-light/down_arrow_lighter.svg);
 }
 
 QSint--ActionGroup QFrame[class="header"] QLabel[fold="true"] {
-background-color: transparent;
-background-image: url(qss:images_dark-light/up_arrow_light.svg);
-background-repeat: none;
-background-position: center center;
-padding: 0px;
-margin: 0px;
+    background-color: transparent;
+    background-image: url(qss:images_dark-light/up_arrow_light.svg);
+    background-repeat: none;
+    background-position: center center;
+    padding: 0px;
+    margin: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"] QLabel[fold="true"]:hover {
-background-color: transparent;
-background-image: url(qss:images_dark-light/up_arrow_lighter.svg);
+    background-color: transparent;
+    background-image: url(qss:images_dark-light/up_arrow_lighter.svg);
 }
 
 QSint--ActionGroup QFrame[class="content"] {
-background-color: transparent; /* Task Panel background color */
-margin: 0px;
-padding: 0px;
-border-bottom: 1px solid #696968;
-border-left: 1px solid #696968;
-border-right: 1px solid #696968;
-border-top-left-radius: 0px;
-border-top-right-radius: 0px;
-border-bottom-left-radius: 3px;
-border-bottom-right-radius: 3px;
+    background-color: transparent; /* Task Panel background color */
+    margin: 0px;
+    padding: 0px;
+    border-bottom: 1px solid #696968;
+    border-left: 1px solid #696968;
+    border-right: 1px solid #696968;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
 }
 
 QSint--ActionGroup QFrame[class="content"] > QWidget {
-background-color: #2b2b2b; /* Task Panel background color */
+    background-color: #2b2b2b; /* Task Panel background color */
 }
 
 /* Fixs for tabs inside Task Panel */
 QSint--ActionGroup QFrame[class="content"] QTabBar::tab:top:selected {
-border-bottom-color: @ThemeAccentColor1; /* same as Task Panel background color */
+    border-bottom-color: @ThemeAccentColor1; /* same as Task Panel background color */
 }
 
 QSint--ActionGroup QFrame[class="content"] QTabBar::tab:bottom:selected {
-border-top-color: @ThemeAccentColor1; /* same as Task Panel background color */
+    border-top-color: @ThemeAccentColor1; /* same as Task Panel background color */
 }
 
 QSint--ActionGroup QFrame[class="content"] QTabBar::tab:right:selected {
-border-right-color: @ThemeAccentColor1; /* same as Task Panel background color */
+    border-right-color: @ThemeAccentColor1; /* same as Task Panel background color */
 }
 
 QSint--ActionGroup QFrame[class="content"] QTabBar::tab:left:selected {
-border-left-color: @ThemeAccentColor1; /* same as Task Panel background color */
+    border-left-color: @ThemeAccentColor1; /* same as Task Panel background color */
 }
 
 /* Fix for buttons with icons that showed cropped (still not happy with result) */
 QSint--ActionGroup QFrame[class="content"] > QWidget > QPushButton {
-padding: 2px; /* bigger padding crops text and icons... */
-margin: 0px;
+    padding: 2px; /* bigger padding crops text and icons... */
+    margin: 0px;
 }
 
 /* Fix for lists inside task panels */ /* sketcher constraints list */
 QSint--ActionGroup QFrame[class="content"] QTreeView,
 QSint--ActionGroup QFrame[class="content"] QListView,
 QSint--ActionGroup QFrame[class="content"] QTableView {
-color: white;
-background-color: black;
+    color: white;
+    background-color: black;
 }
 
 
 /* found inside Part Design Workbench and "make a draft on a face" Task panel options */
 QSint--ActionGroup QFrame[class="content"] QToolButton {
-  color: white;
-  text-align: center;
-  background-color: #696969;
-  border: 0px solid #adadad;
-  padding: 1px 1px; /* different than regular QPushButton */
-  margin: 0px; /* different than regular QPushButton */
-  min-height: 16px; /* same as QTabBar QPushButton min-width */
-  border-radius: 1px;
+    color: white;
+    text-align: center;
+    background-color: #696969;
+    border: 0px solid #adadad;
+    padding: 1px 1px; /* different than regular QPushButton */
+    margin: 0px; /* different than regular QPushButton */
+    min-height: 16px; /* same as QTabBar QPushButton min-width */
+    border-radius: 1px;
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover{
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:disabled,
@@ -1657,8 +1675,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
-
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 /* QSlider ----------------------------------------------------------------
@@ -1667,47 +1684,47 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qslider
 
 --------------------------------------------------------------------------- */
 QSlider:disabled {
-  background: #2b2b2b;
+    background: #2b2b2b;
 }
 
-QSlider:focus {
-  /*border: 1px solid @ThemeAccentColor2;*/
-}
+/* QSlider:focus {
+    border: 1px solid @ThemeAccentColor2;
+} */
 
 QSlider::groove:horizontal {
-  background: #2b2b2b;
-  border: 1px solid #696968;
-  height: 4px;
-  margin: 0px;
-  border-radius: 1.9px;
+    background: #2b2b2b;
+    border: 1px solid #696968;
+    height: 4px;
+    margin: 0px;
+    border-radius: 1.9px;
 }
 
 QSlider::groove:vertical {
-  background: @ThemeAccentColor1;
-  border: 1px solid #696968;
-  width: 4px;
-  margin: 0px;
-  border-radius: 1.9px;
+    background: @ThemeAccentColor1;
+    border: 1px solid #696968;
+    width: 4px;
+    margin: 0px;
+    border-radius: 1.9px;
 }
 
 QSlider::add-page:vertical {
-  background: @ThemeAccentColor1;
-  border: 1px solid #696968;
-  width: 4px;
-  margin: 0px;
-  border-radius: 1.9px;
+    background: @ThemeAccentColor1;
+    border: 1px solid #696968;
+    width: 4px;
+    margin: 0px;
+    border-radius: 1.9px;
 }
 
 QSlider::add-page:vertical :disabled {
-  background: #696968;
+    background: #696968;
 }
 
 QSlider::sub-page:horizontal {
-  background: @ThemeAccentColor1;
-  border: 1px solid #696968;
-  height: 4px;
-  margin: 0px;
-  border-radius: 1.9px;
+    background: @ThemeAccentColor1;
+    border: 1px solid #696968;
+    height: 4px;
+    margin: 0px;
+    border-radius: 1.9px;
 }
 
 QSlider::sub-page:horizontal:disabled {
@@ -1724,31 +1741,31 @@ QSlider::handle:horizontal {
 }
 
 QSlider::handle:horizontal:hover {
-  background: @ThemeAccentColor1;
-  border: 1px solid #696968;
+    background: @ThemeAccentColor1;
+    border: 1px solid #696968;
 }
 
 QSlider::handle:horizontal:focus {
-  background: @ThemeAccentColor2;
-  border: 1px solid @ThemeAccentColor2;
+    background: @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QSlider::handle:vertical {
-  background: #696968;
-  border: 1px solid #696968;
-  width: 10px;
-  height: 8px;
-  margin: 0px -4px;
-  border-radius: 6px;
+    background: #696968;
+    border: 1px solid #696968;
+    width: 10px;
+    height: 8px;
+    margin: 0px -4px;
+    border-radius: 6px;
 }
 
 QSlider::handle:vertical:hover {
-  background: @ThemeAccentColor1;
-  border: 1px solid #696968;
+    background: @ThemeAccentColor1;
+    border: 1px solid #696968;
 }
 
 QSlider::handle:vertical:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 /* QLineEdit --------------------------------------------------------------
@@ -1757,36 +1774,36 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qlineedit
 
 --------------------------------------------------------------------------- */
 QLineEdit {
-  background-color: #1c1b22;
-  padding-top: 2px;
-  /* This QLineEdit fix  103, 111 */
-  padding-bottom: 2px;
-  /* This QLineEdit fix  103, 111 */
-  padding-left: 4px;
-  padding-right: 4px;
-  border-style: solid;
-  border: 1px solid #696968;
-  border-radius: 2px;
-  color: White;
+    background-color: #1c1b22;
+    padding-top: 2px;
+    /* This QLineEdit fix  103, 111 */
+    padding-bottom: 2px;
+    /* This QLineEdit fix  103, 111 */
+    padding-left: 4px;
+    padding-right: 4px;
+    border-style: solid;
+    border: 1px solid #696968;
+    border-radius: 2px;
+    color: White;
 }
 
 QLineEdit:disabled {
-  background-color: #2b2b2b;
-  color: #c2c7cb;
+    background-color: #2b2b2b;
+    color: #c2c7cb;
 }
 
 QLineEdit:hover {
-  border: 1px solid @ThemeAccentColor1;
-  color: White;
+    border: 1px solid @ThemeAccentColor1;
+    color: White;
 }
 
 QLineEdit:focus {
-  border: 2px solid @ThemeAccentColor2;
+    border: 2px solid @ThemeAccentColor2;
 }
 
 QLineEdit:selected {
-  background-color: @ThemeAccentColor1;
-  color: white;
+    background-color: @ThemeAccentColor1;
+    color: white;
 }
 
 /* QTabWiget --------------------------------------------------------------
@@ -1795,152 +1812,153 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabb
 
 --------------------------------------------------------------------------- */
 QTabWidget {
-  padding: 2px;
-  selection-background-color: @ThemeAccentColor1;
+    padding: 2px;
+    selection-background-color: @ThemeAccentColor1;
 }
 
 QTabWidget QWidget {
-  /* Fixes #189 */
-  border-radius: 0px;
+    /* Fixes #189 */
+    border-radius: 0px;
 }
 
 QTabWidget::pane {
-  border: 0px solid #8c00ffa1;
-  border-radius: 1.9px;
-  margin: 0px;
-  /* Fixes double border inside pane with pyqt5 */
-  padding: 0px;
-  background-color: #2b2b2b;
+    border: 0px solid #8c00ffa1;
+    border-radius: 1.9px;
+    margin: 0px;
+    /* Fixes double border inside pane with pyqt5 */
+    padding: 0px;
+    background-color: #2b2b2b;
 }
 
 QTabWidget::pane:selected {
-  background-color: @ThemeAccentColor1;
-  border: 1px solid #346792;
+    background-color: @ThemeAccentColor1;
+    border: 1px solid #346792;
 }
+
 /* QTabBar ----------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabbar
 
 --------------------------------------------------------------------------- */
 QTabBar, QDockWidget QTabBar {
-  qproperty-drawBase: 0;
-  border-radius: 2px;
-  margin: 0px;
-  padding: 2px;
-  border: 0;
-  alignment: center;
-  /* left: 5px; move to the right by 5px - removed for fix */
+    qproperty-drawBase: 0;
+    border-radius: 2px;
+    margin: 0px;
+    padding: 2px;
+    border: 0;
+    alignment: center;
+    /* left: 5px; move to the right by 5px - removed for fix */
 }
 
 QTabBar::close-button, QDockWidget QTabBar::close-button {
-  border: 0;
-  margin: 0;
-  padding: 1px;
-  image: url(qss:images_dark-light/close_light.svg);
+    border: 0;
+    margin: 0;
+    padding: 1px;
+    image: url(qss:images_dark-light/close_light.svg);
 }
 
 QTabBar::close-button:hover, QDockWidget QTabBar::close-button:hover {
-  image: url(qss:images_dark-light/close_red.svg);
-  /*background-color: rgba(255, 0, 0, 0.3);*/
+    image: url(qss:images_dark-light/close_red.svg);
+    /*background-color: rgba(255, 0, 0, 0.3);*/
 }
 
 QTabBar::close-button:pressed, QDockWidget QTabBar::close-button:pressed {
-  image: url(qss:images_dark-light/close_.svg);
+    image: url(qss:images_dark-light/close_.svg);
 }
 
 QTabBar::tab, QDockWidget QTabBar::tab {
-  /* !selected and disabled ----------------------------------------- */
-  /* selected ------------------------------------------------------- */
+    /* !selected and disabled ----------------------------------------- */
+    /* selected ------------------------------------------------------- */
 }
 
 QTabBar::tab:top:selected:disabled, QDockWidget QTabBar::tab:top:selected:disabled {
-  border-bottom: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-bottom: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:bottom:selected:disabled, QDockWidget QTabBar::tab:bottom:selected:disabled {
-  border-top: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-top: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:left:selected:disabled, QDockWidget QTabBar::tab:left:selected:disabled {
-  border-right: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-right: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:right:selected:disabled, QDockWidget QTabBar::tab:right:selected:disabled {
-  border-left: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-left: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:top:!selected:disabled, QDockWidget QTabBar::tab:top:!selected:disabled {
-  border-bottom: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-bottom: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:bottom:!selected:disabled, QDockWidget QTabBar::tab:bottom:!selected:disabled {
-  border-top: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-top: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:left:!selected:disabled, QDockWidget QTabBar::tab:left:!selected:disabled {
-  border-right: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-right: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:right:!selected:disabled, QDockWidget QTabBar::tab:right:!selected:disabled {
-  border-left: 3px solid #696969;
-  color: #515151;
-  background-color: #696969;
+    border-left: 3px solid #696969;
+    color: #515151;
+    background-color: #696969;
 }
 
 QTabBar::tab:top:!selected, QDockWidget QTabBar::tab:top:!selected {
-  border-bottom: 2px solid #696969;
-  margin-top: 2px;
+    border-bottom: 2px solid #696969;
+    margin-top: 2px;
 }
 
 QTabBar::tab:bottom:!selected, QDockWidget QTabBar::tab:bottom:!selected {
-  border-top: 2px solid #696969;
-  margin-bottom: 2px;
+    border-top: 2px solid #696969;
+    margin-bottom: 2px;
 }
 
 QTabBar::tab:left:!selected, QDockWidget QTabBar::tab:left:!selected {
-  border-left: 2px solid #696969;
-  margin-right: 2px;
+    border-left: 2px solid #696969;
+    margin-right: 2px;
 }
 
 QTabBar::tab:right:!selected, QDockWidget QTabBar::tab:right:!selected {
-  border-right: 2px solid #696969;
-  margin-left: 2px;
+    border-right: 2px solid #696969;
+    margin-left: 2px;
 }
 
 QTabBar::tab:top, QDockWidget QTabBar::tab:top {
-  background-color: #2b2b2b;
-  margin-left: 3px;
-  padding-left: 4px;
-  padding-right: 4px;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  min-width: 5px;
-  border: 1px solid #696969;
-  border-radius: 4px;
+    background-color: #2b2b2b;
+    margin-left: 3px;
+    padding-left: 4px;
+    padding-right: 4px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    min-width: 5px;
+    border: 1px solid #696969;
+    border-radius: 4px;
 }
 
 QTabBar::tab:top:selected, QDockWidget QTabBar::tab:top:selected {
-  background-color: #696969;
-  /*border: 1px solid @ThemeAccentColor2;
-  border-radius: 4px;
-  margin-left: 4px;
-  margin-right: 4px;
-  padding-left: 3px;
-  padding-right: 3px;*/
+    background-color: #696969;
+    /*border: 1px solid @ThemeAccentColor2;
+    border-radius: 4px;
+    margin-left: 4px;
+    margin-right: 4px;
+    padding-left: 3px;
+  vpadding-right: 3px;*/
 }
 
 QTabBar::tab:top:!selected:hover, QDockWidget QTabBar::tab:top:!selected:hover {
@@ -1953,175 +1971,177 @@ QTabBar::tab:top:!selected:hover, QDockWidget QTabBar::tab:top:!selected:hover {
 }
 
 QTabBar::tab:bottom, QDockWidget QTabBar::tab:bottom {
-  border: 1px solid #696969;
-  background-color: #2b2b2b;
-  margin-left: 3px;
-  padding-left: 4px;
-  padding-right: 4px;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  border-radius: 4px;
-  min-width: 5px;
+    border: 1px solid #696969;
+    background-color: #2b2b2b;
+    margin-left: 3px;
+    padding-left: 4px;
+    padding-right: 4px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border-radius: 4px;
+    min-width: 5px;
 }
 
 QTabBar::tab:bottom:selected, QDockWidget QTabBar::tab:bottom:selected {
-  background-color: #696969;
-  /*border: 1px solid @ThemeAccentColor2;
-  border-radius: 4px;
-  margin-left: 4px;
-  margin-right: 4px;
-  padding-left: 3px;
-  padding-right: 3px;*/
+    background-color: #696969;
+    /*border: 1px solid @ThemeAccentColor2;
+    border-radius: 4px;
+    margin-left: 4px;
+    margin-right: 4px;
+    padding-left: 3px;
+    padding-right: 3px;*/
 }
 
 QTabBar::tab:bottom:!selected:hover, QDockWidget QTabBar::tab:bottom:!selected:hover {
-/*border: 1px solid @ThemeAccentColor1;*/
-  border: 0px solid @ThemeAccentColor1;
-  background-color: @ThemeAccentColor1;
-  /* Fixes spyder-ide/spyder#9766 and #243 */
-  padding-left: 3px;
-  padding-right: 3px;
+    /*border: 1px solid @ThemeAccentColor1;*/
+    border: 0px solid @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
+    /* Fixes spyder-ide/spyder#9766 and #243 */
+    padding-left: 3px;
+    padding-right: 3px;
 }
 
+
+
 QTabBar::tab:left, QDockWidget QTabBar::tab:left {
-  background-color: #2b2b2b;
-  margin-top: 2px;
-  padding-left: 2px;
-  padding-right: 2px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  border-radius: 4px;
-  min-height: 5px;
+    background-color: #2b2b2b;
+    margin-top: 2px;
+    padding-left: 2px;
+    padding-right: 2px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    border-radius: 4px;
+    min-height: 5px;
 }
 
 QTabBar::tab:left:selected, QDockWidget QTabBar::tab:left:selected {
-  background-color: #2b2b2b;
-  border: 0px solid @ThemeAccentColor2;
+    background-color: #2b2b2b;
+    border: 0px solid @ThemeAccentColor2;
 }
 
 QTabBar::tab:left:!selected:hover, QDockWidget QTabBar::tab:left:!selected:hover {
-  border: 0px solid @ThemeAccentColor1;
-  background-color: @ThemeAccentColor1;
-  /* Fixes different behavior #271 */
-  margin-right: 0px;
-  padding-right: -1px;
+    border: 0px solid @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
+    /* Fixes different behavior #271 */
+    margin-right: 0px;
+    padding-right: -1px;
 }
 
 QTabBar::tab:right, QDockWidget QTabBar::tab:right {
-  background-color: #2b2b2b;
-  margin-top: 2px;
-  padding-left: 2px;
-  padding-right: 2px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  min-height: 5px;
-  border: 10px;
+    background-color: #2b2b2b;
+    margin-top: 2px;
+    padding-left: 2px;
+    padding-right: 2px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    min-height: 5px;
+    border: 10px;
 }
 
 QTabBar::tab:right:selected, QDockWidget QTabBar::tab:right:selected {
-  background-color: #2b2b2b;
-  border: 0px solid @ThemeAccentColor2;
+    background-color: #2b2b2b;
+    border: 0px solid @ThemeAccentColor2;
 }
 
 QTabBar::tab:right:!selected:hover, QDockWidget QTabBar::tab:right:!selected:hover {
-  border: 0px solid @ThemeAccentColor1;
-  background-color: @ThemeAccentColor1;
-  /* Fixes different behavior #271 */
-  margin-left: 0px;
-  padding-left: 0px;
+    border: 0px solid @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
+    /* Fixes different behavior #271 */
+    margin-left: 0px;
+    padding-left: 0px;
 }
 
 QTabBar QToolButton, QDockWidget QTabBar QToolButton {
-  /* Fixes #136 */
-  background-color: #2b2b2b;
-  height: 12px;
-  width: 12px;
+    /* Fixes #136 */
+    background-color: #2b2b2b;
+    height: 12px;
+    width: 12px;
 }
 
 QTabBar QToolButton:pressed, QDockWidget QTabBar QToolButton:pressed {
-  border: 0px solid @ThemeAccentColor1;
-  background-color: @ThemeAccentColor1;
+    border: 0px solid @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QTabBar QToolButton:pressed:hover, QDockWidget QTabBar QToolButton:pressed:hover {
-  border: 0px solid @ThemeAccentColor1;
-  background-color: @ThemeAccentColor1;
+    border: 0px solid @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QTabBar QToolButton::left-arrow:enabled, QDockWidget QTabBar QToolButton::left-arrow:enabled {
-  image: url(qss:images_dark-light/left_arrow_lighter.svg);
+    image: url(qss:images_dark-light/left_arrow_lighter.svg);
 }
 
 QTabBar QToolButton::left-arrow:disabled, QDockWidget QTabBar QToolButton::left-arrow:disabled {
-  image: url(qss:images_dark-light/left_arrow_disabled_light.svg);
+    image: url(qss:images_dark-light/left_arrow_disabled_light.svg);
 }
 
 QTabBar QToolButton::right-arrow:enabled, QDockWidget QTabBar QToolButton::right-arrow:enabled {
-  image: url(qss:images_dark-light/right_arrow_lighter.svg);
+    image: url(qss:images_dark-light/right_arrow_lighter.svg);
 }
 
 QTabBar QToolButton::right-arrow:disabled, QDockWidget QTabBar QToolButton::right-arrow:disabled {
-  image: url(qss:images_dark-light/right_arrow_disabled_light.svg);
+    image: url(qss:images_dark-light/right_arrow_disabled_light.svg);
 }
 
 /* QDockWiget -------------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QDockWidget {
-  background-color: #2b2b2b;
-  border: 1px solid #696968;
-  border-radius: 1.9px;
-  titlebar-close-icon: url(qss:images_dark-light/transparent.svg);
-  titlebar-normal-icon: url(qss:images_dark-light/transparent.svg);
+    background-color: #2b2b2b;
+    border: 1px solid #696968;
+    border-radius: 1.9px;
+    titlebar-close-icon: url(qss:images_dark-light/transparent.svg);
+    titlebar-normal-icon: url(qss:images_dark-light/transparent.svg);
 }
 
 QDockWidget::title {
-  /* Better size for title bar */
-  padding: 3px;
-  spacing: 4px;
-  border: none;
-  background-color: #2b2b2b;
-  text-align: center;
-  font-weight: bold;
+    /* Better size for title bar */
+    padding: 3px;
+    spacing: 4px;
+    border: none;
+    background-color: #2b2b2b;
+    text-align: center;
+    font-weight: bold;
 }
 
 QDockWidget::close-button {
-  icon-size: 10px;
-  border: none;
-  background: transparent;
-  background-image: transparent;
-  border: 0;
-  margin: 0;
-  padding: 0;
-  image: url(qss:images_dark-light/close_light.svg);
+    icon-size: 10px;
+    border: none;
+    background: transparent;
+    background-image: transparent;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    image: url(qss:images_dark-light/close_light.svg);
 }
 
 QDockWidget::close-button:hover {
-  image: url(qss:images_dark-light/close_red.svg);
+    image: url(qss:images_dark-light/close_red.svg);
 }
 
 QDockWidget::close-button:pressed {
-  image: url(qss:images_dark-light/close_light.svg);
+    image: url(qss:images_dark-light/close_light.svg);
 }
 
 QDockWidget::float-button {
-  icon-size: 12px;
-  border: none;
-  background: transparent;
-  background-image: transparent;
-  border: 0;
-  margin: 0;
-  padding: 0;
-  image: url(qss:images_dark-light/undock_light.svg);
+    icon-size: 12px;
+    border: none;
+    background: transparent;
+    background-image: transparent;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    image: url(qss:images_dark-light/undock_light.svg);
 }
 
 QDockWidget::float-button:hover {
-  /*background-color: @ThemeAccentColor1;*/
-  image: url(qss:images_dark-light/undock_blue.svg);
+    /*background-color: @ThemeAccentColor1;*/
+    image: url(qss:images_dark-light/undock_blue.svg);
 }
 
 QDockWidget::float-button:pressed {
-  image: url(qss:images_dark-light/undock_light.svg);
+    image: url(qss:images_dark-light/undock_light.svg);
 }
 
 /* QTreeView QListView QTableView -----------------------------------------
@@ -2131,43 +2151,43 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qlistview
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtableview
 
 --------------------------------------------------------------------------- */
-QTreeView::branch  {
-  background: transparent;
+QTreeView::branch {
+    background: transparent;
 }
 
-QTreeView::branch:has-siblings:!adjoins-item  {
-  border-image: url(qss:images_dark-light/branch_vline_light.svg) 0;
+QTreeView::branch:has-siblings:!adjoins-item {
+    border-image: url(qss:images_dark-light/branch_vline_light.svg) 0;
 }
 
-QTreeView::branch:has-siblings:adjoins-item  {
-  border-image: url(qss:images_dark-light/branch_more_light.svg) 0;
+QTreeView::branch:has-siblings:adjoins-item {
+    border-image: url(qss:images_dark-light/branch_more_light.svg) 0;
 }
 
-QTreeView::branch:!has-children:!has-siblings:adjoins-item  {
-  border-image: url(qss:images_dark-light/branch_end_light.svg) 0;
+QTreeView::branch:!has-children:!has-siblings:adjoins-item {
+    border-image: url(qss:images_dark-light/branch_end_light.svg) 0;
 }
 
-QTreeView::branch:closed:has-children:has-siblings  {
-  border-image: url(qss:images_dark-light/branch_more_closed_light.svg) 0;
+QTreeView::branch:closed:has-children:has-siblings {
+    border-image: url(qss:images_dark-light/branch_more_closed_light.svg) 0;
 }
 
-QTreeView::branch:has-children:!has-siblings:closed  {
-  border-image: url(qss:images_dark-light/branch_end_closed_light.svg) 0;
+QTreeView::branch:has-children:!has-siblings:closed {
+    border-image: url(qss:images_dark-light/branch_end_closed_light.svg) 0;
 }
 
-QTreeView::branch:open:has-children:has-siblings  {
-  border-image: url(qss:images_dark-light/branch_more_open_light.svg) 0;
+QTreeView::branch:open:has-children:has-siblings {
+    border-image: url(qss:images_dark-light/branch_more_open_light.svg) 0;
 }
 
-QTreeView::branch:open:has-children:!has-siblings  {
-  border-image: url(qss:images_dark-light/branch_end_open_light.svg) 0;
+QTreeView::branch:open:has-children:!has-siblings {
+    border-image: url(qss:images_dark-light/branch_end_open_light.svg) 0;
 }
 
 QTreeView::indicator:checked,
 QListView::indicator:checked,
 QTableView::indicator:checked,
 QColumnView::indicator:checked {
-  image: url(qss:images_dark-light/checkbox_light.svg);
+    image: url(qss:images_dark-light/checkbox_light.svg);
 }
 
 QTreeView::indicator:checked:hover, QTreeView::indicator:checked:focus, QTreeView::indicator:checked:pressed,
@@ -2180,14 +2200,14 @@ QTableView::indicator:checked:pressed,
 QColumnView::indicator:checked:hover,
 QColumnView::indicator:checked:focus,
 QColumnView::indicator:checked:pressed {
-  image: url(qss:images_dark-light/checkbox_light_hover.svg);
+    image: url(qss:images_dark-light/checkbox_light_hover.svg);
 }
 
 QTreeView::indicator:unchecked,
 QListView::indicator:unchecked,
 QTableView::indicator:unchecked,
 QColumnView::indicator:unchecked {
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QTreeView::indicator:unchecked:hover, QTreeView::indicator:unchecked:focus, QTreeView::indicator:unchecked:pressed,
@@ -2200,14 +2220,14 @@ QTableView::indicator:unchecked:pressed,
 QColumnView::indicator:unchecked:hover,
 QColumnView::indicator:unchecked:focus,
 QColumnView::indicator:unchecked:pressed {
-  image: url(qss:images_dark-light/checkbox_unchecked_hover_light.svg);
+    image: url(qss:images_dark-light/checkbox_unchecked_hover_light.svg);
 }
 
 QTreeView::indicator:indeterminate,
 QListView::indicator:indeterminate,
 QTableView::indicator:indeterminate,
 QColumnView::indicator:indeterminate {
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QTreeView::indicator:indeterminate:hover, QTreeView::indicator:indeterminate:focus, QTreeView::indicator:indeterminate:pressed,
@@ -2220,23 +2240,23 @@ QTableView::indicator:indeterminate:pressed,
 QColumnView::indicator:indeterminate:hover,
 QColumnView::indicator:indeterminate:focus,
 QColumnView::indicator:indeterminate:pressed {
-  image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
+    image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
 QTreeView,
 QListView,
 QTableView,
 QColumnView {
-  background-color: #2b2b2b;  /* background of a lot of stuff including spreadsheets.*/
-  border: 0px solid #696968;
-  color: White;
-  gridline-color: #696968;
-  border-radius: 0px;
+    background-color: #2b2b2b;  /* background of a lot of stuff including spreadsheets.*/
+    border: 0px solid #696968;
+    color: White;
+    gridline-color: #696968;
+    border-radius: 0px;
 }
 
 QTableView,
 QListView  {
-  background-color: rgba(31, 31, 31, 0.85);  /* background of a lot of stuff including spreadsheets.*/
+    background-color: rgba(31, 31, 31, 0.85);  /* background of a lot of stuff including spreadsheets.*/
 }
 
 
@@ -2244,65 +2264,66 @@ QTreeView:disabled,
 QListView:disabled,
 QTableView:disabled,
 QColumnView:disabled {
-  background-color: #1c1b22;
-  color: #c2c7cb;
+    background-color: #1c1b22;
+    color: #c2c7cb;
 }
 
 QTreeView:selected,
 QListView:selected,
 QTableView:selected,
 QColumnView:selected {
-  background-color: @ThemeAccentColor1;
-  color: White;
+    background-color: @ThemeAccentColor1;
+    color: White;
 }
 
 QTreeView:focus,
 QListView:focus,
 QTableView:focus,
 QColumnView:focus {
-  border: 1px solid @ThemeAccentColor2;
+    border: 1px solid @ThemeAccentColor2;
 }
 
 QTreeView::item:pressed,
 QListView::item:pressed,
 QTableView::item:pressed,
 QColumnView::item:pressed {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:selected:active,
 QListView::item:selected:active,
 QTableView::item:selected:active,
 QColumnView::item:selected:active {
-  background-color: @ThemeAccentColor1;
+    background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:selected:!active,
 QListView::item:selected:!active,
 QTableView::item:selected:!active,
 QColumnView::item:selected:!active {
-  color: White;
-  background-color: #353535;
+    color: White;
+    background-color: #353535;
 }
 
 QTreeView::item:!selected:hover,
 QListView::item:!selected:hover,
 QTableView::item:!selected:hover,
 QColumnView::item:!selected:hover {
-  outline: 0;
-  color: White;
-  background-color: @ThemeAccentColor1;
+    outline: 0;
+    color: White;
+    background-color: @ThemeAccentColor1;
 }
 
 QTableCornerButton::section {
-  background-color: #2b2b2b;
-  border: 1px transparent #696968;
-  border-radius: 0px;
+    background-color: #2b2b2b;
+    border: 1px transparent #696968;
+    border-radius: 0px;
 }
 
 QTableView::item {
     color: white;
 }
+
 QTableView {
   /*qproperty-AliasedCellBackgroundColor: #f700ff;*/
   /*qproperty-aliasBgColor: #f700ff;*/
@@ -2314,82 +2335,82 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qheaderview
 
 --------------------------------------------------------------------------- */
 QHeaderView {
-  background-color: #2b2b2b;
-  border: 1px solid #696968;
-  padding: 0;
-  margin: 0;
-  border-radius: 0px;
-  text-align: center;
+    background-color: #2b2b2b;
+    border: 1px solid #696968;
+    padding: 0;
+    margin: 0;
+    border-radius: 0px;
+    text-align: center;
 }
 
 QHeaderView:disabled {
-  background-color: #2b2b2b;
-  border: 1px solid #696968;
-  color: rgb(174, 174, 174);
+    background-color: #2b2b2b;
+    border: 1px solid #696968;
+    color: rgb(174, 174, 174);
 }
 
 QHeaderView::section {
-  background-color: #3c3c3c;
-  color: White;
-  border-radius: 0px;
-  font-size: 13px;
-  font-weight: bold;
-  text-align: center;
+    background-color: #3c3c3c;
+    color: White;
+    border-radius: 0px;
+    font-size: 13px;
+    font-weight: bold;
+    text-align: center;
 }
 
 QHeaderView::section::horizontal {
-  padding-top: 0;
-  padding-bottom: 0;
-  padding-left: 10px;
-  padding-right: 10px;
-  border-left: 1px solid #696968;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 10px;
+    padding-right: 10px;
+    border-left: 1px solid #696968;
 }
 
 QHeaderView::section::horizontal::first, QHeaderView::section::horizontal::only-one {
-  border-left: 1px solid #696968;
-  padding-left: 15px;
+    border-left: 1px solid #696968;
+    padding-left: 15px;
 }
 
 QHeaderView::section::horizontal:disabled {
-  color: #353535;
+    color: #353535;
 }
 
 QHeaderView::section::vertical {
-  padding-top: 0;
-  padding-bottom: 0;
-  padding-left: 1px;
-  padding-right: 1px;
-  border-top: 1px solid #696968;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 1px;
+    padding-right: 1px;
+    border-top: 1px solid #696968;
 }
 
 QHeaderView::section::vertical::first, QHeaderView::section::vertical::only-one {
-  border-top: 1px solid #696968;
+    border-top: 1px solid #696968;
 }
 
 QHeaderView::section::vertical:disabled {
-  color: #7a7a7a;
+    color: #7a7a7a;
 }
 
 QHeaderView::down-arrow {
-  /* Those settings (border/width/height/background-color) solve bug */
-  /* transparent arrow background and size */
-  background-color: #696969;
-  border: none;
-  height: 12px;
-  width: 12px;
-  padding-left: 2px;
-  padding-right: 2px;
-  image: url(qss:images_dark-light/down_arrow_light.svg);
+    /* Those settings (border/width/height/background-color) solve bug */
+    /* transparent arrow background and size */
+    background-color: #696969;
+    border: none;
+    height: 12px;
+    width: 12px;
+    padding-left: 2px;
+    padding-right: 2px;
+    image: url(qss:images_dark-light/down_arrow_light.svg);
 }
 
 QHeaderView::up-arrow {
-  background-color: #696969;
-  border: none;
-  height: 12px;
-  width: 12px;
-  padding-left: 2px;
-  padding-right: 2px;
-  image: url(qss:images_dark-light/up_arrow_light.svg);
+    background-color: #696969;
+    border: none;
+    height: 12px;
+    width: 12px;
+    padding-left: 2px;
+    padding-right: 2px;
+    image: url(qss:images_dark-light/up_arrow_light.svg);
 }
 
 /* QToolBox --------------------------------------------------------------
@@ -2399,59 +2420,58 @@ used in PATH
 
 --------------------------------------------------------------------------- */
 QToolBox {
-  padding: 0px;
-  border: 1px solid #696969;
-  border-radius: 4px;
-  background-color: transparent;
+    padding: 0px;
+    border: 1px solid #696969;
+    border-radius: 4px;
+    background-color: transparent;
 }
 
 QToolBox:selected {
-  padding: 0px;
-  border: 0px solid @ThemeAccentColor1;
+    padding: 0px;
+    border: 0px solid @ThemeAccentColor1;
 }
 
 QToolBox::tab {
-  background-color: #696969;
-  border: 0px solid #696969;
-  color: white;
-  background-image: url(qss:images_dark-light/down_arrow_lighter.svg);
-  background-repeat: none;
-  background-position: center left;
+    background-color: #696969;
+    border: 0px solid #696969;
+    color: white;
+    background-image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    background-repeat: none;
+    background-position: center left;
 }
 
 QToolBox::tab:disabled {
-  color: #696969;
+    color: #696969;
 }
 
 QToolBox::tab:selected {
-  background-color: #696969;
-  background-image: url(qss:images_dark-light/transparent.svg);
-  padding-right: 5px;
-  background-repeat: none;
+    background-color: #696969;
+    background-image: url(qss:images_dark-light/transparent.svg);
+    padding-right: 5px;
+    background-repeat: none;
 }
 
 QToolBox::tab:selected:disabled {
-  background-color: #696969;
-  border-bottom: 0px solid #cccccc;
-  color: white;
+    background-color: #696969;
+    border-bottom: 0px solid #cccccc;
+    color: white;
 }
 
-QToolBox::tab:!selected {
-
-}
+/* QToolBox::tab:!selected {
+} */
 
 QToolBox::tab:!selected:disabled {
-  background-color: #2b2b2b;
+    background-color: #2b2b2b;
 }
 
 QToolBox::tab:hover {
-  background-color: @ThemeAccentColor1;
-  }
+    background-color: @ThemeAccentColor1;
+}
 
 QToolBox QScrollArea QWidget QWidget {
-  padding: 0px;
-  border: 0px;
-  background-color: transparent;
+    padding: 0px;
+    border: 0px;
+    background-color: transparent;
 }
 
 /* QFrame -----------------------------------------------------------------
@@ -2464,29 +2484,29 @@ https://stackoverflow.com/questions/14581498/qt-stylesheet-for-hline-vline-color
 --------------------------------------------------------------------------- */
 /* (dot) .QFrame  fix #141, #126, #123 */
 .QFrame {
-  border-radius: 0px;
-  border: 0px solid #696968;
-  background-color: #696969;
-  /* No frame */
-  /* HLine */
-  /* HLine */
+    border-radius: 0px;
+    border: 0px solid #696968;
+    background-color: #696969;
+    /* No frame */
+    /* HLine */
+    /* HLine */
 }
 
 .QFrame[frameShape="0"] {
-  border-radius: 1.9px;
-  border: 1px solid #696968;
+    border-radius: 1.9px;
+    border: 1px solid #696968;
 }
 
 .QFrame[frameShape="4"] {
-  max-height: 1px;
-  border: none;
-  background-color: #696968;
+    max-height: 1px;
+    border: none;
+    background-color: #696968;
 }
 
 .QFrame[frameShape="5"] {
-  max-width: 1px;
-  border: none;
-  background-color: #2b2b2b;
+    max-width: 1px;
+    border: none;
+    background-color: #2b2b2b;
 }
 
 /* QSplitter --------------------------------------------------------------
@@ -2494,108 +2514,107 @@ https://stackoverflow.com/questions/14581498/qt-stylesheet-for-hline-vline-color
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qsplitter
 
 ---------------------------------------------------------------------------*/
-QSplitterHandle:hover { /* to fix bug about hovering on splitters https://bugreports.qt.io/browse/QTBUG-13768 */
-
-}
+/*QSplitterHandle:hover { /* to fix bug about hovering on splitters https://bugreports.qt.io/browse/QTBUG-13768
+}*/
 
 QSplitter::handle {
-  margin: 0px 0px;
-  padding: 0px;
+    margin: 0px 0px;
+    padding: 0px;
 }
 
 QSplitter::handle:horizontal {
-  background-image: none;
-  background-position: center center;
-  background-repeat: none;
-  margin: 2px 2px 2px 2px;
-  width: 1px;
+    background-image: none;
+    background-position: center center;
+    background-repeat: none;
+    margin: 2px 2px 2px 2px;
+    width: 1px;
 }
 
 QSplitter::handle:vertical {
-  background-image: none;
-  background-position: center center;
-  background-repeat: none;
-  margin: 2px 2px 2px 2px;
-  height: 1px;
+    background-image: none;
+    background-position: center center;
+    background-repeat: none;
+    margin: 2px 2px 2px 2px;
+    height: 1px;
 }
 QSplitter::handle:vertical:hover {
-  background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
-  background-position: center center;
-  background-repeat: none;
-  }
+    background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
+    background-position: center center;
+    background-repeat: none;
+}
 
 QSplitter::handle:vertical:hover {
-  background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
-  background-position: center center;
-  background-repeat: none;
-  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
+    background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
+    background-position: center center;
+    background-repeat: none;
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
 }
 
 /* QDateEdit, QDateTimeEdit -----------------------------------------------
 
 --------------------------------------------------------------------------- */
 QDateEdit, QDateTimeEdit {
-  selection-background-color: @ThemeAccentColor1;
-  border-style: solid;
-  border: 1px solid #696968;
-  border-radius: 1.9px;
-  /* This fixes 103, 111 */
-  padding-top: 2px;
-  /* This fixes 103, 111 */
-  padding-bottom: 2px;
-  padding-left: 4px;
-  padding-right: 4px;
-  min-width: 10px;
+    selection-background-color: @ThemeAccentColor1;
+    border-style: solid;
+    border: 1px solid #696968;
+    border-radius: 1.9px;
+    /* This fixes 103, 111 */
+    padding-top: 2px;
+    /* This fixes 103, 111 */
+    padding-bottom: 2px;
+    padding-left: 4px;
+    padding-right: 4px;
+    min-width: 10px;
 }
 
 QDateEdit:on, QDateTimeEdit:on {
-  selection-background-color: @ThemeAccentColor1;
+    selection-background-color: @ThemeAccentColor1;
 }
 
 QDateEdit::drop-down, QDateTimeEdit::drop-down {
-  subcontrol-origin: padding;
-  subcontrol-position: top right;
-  width: 12px;
-  border-left: 1px solid #696968;
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 12px;
+    border-left: 1px solid #696968;
 }
 
 QDateEdit::down-arrow, QDateTimeEdit::down-arrow {
-  image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
-  height: 8px;
-  width: 8px;
+    image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
+    height: 8px;
+    width: 8px;
 }
 
 QDateEdit::down-arrow:on, QDateEdit::down-arrow:hover, QDateEdit::down-arrow:focus, QDateTimeEdit::down-arrow:on, QDateTimeEdit::down-arrow:hover, QDateTimeEdit::down-arrow:focus {
-  image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    image: url(qss:images_dark-light/down_arrow_lighter.svg);
 }
 
 QDateEdit QAbstractItemView, QDateTimeEdit QAbstractItemView {
-  background-color: #2b2b2b;
-  border-radius: 2px;
-  border: 1px solid #696968;
-  selection-background-color: @ThemeAccentColor1;
+    background-color: #2b2b2b;
+    border-radius: 2px;
+    border: 1px solid #696968;
+    selection-background-color: @ThemeAccentColor1;
 }
 
 /* QAbstractView ----------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 QAbstractView:hover {
-  border: 1px solid @ThemeAccentColor1;
-  color: White;
+    border: 1px solid @ThemeAccentColor1;
+    color: White;
 }
 
 QAbstractView:selected {
-  background: @ThemeAccentColor1;
-  color: White;
+    background: @ThemeAccentColor1;
+    color: White;
 }
 
 /* PlotWidget -------------------------------------------------------------
 
 --------------------------------------------------------------------------- */
 PlotWidget {
-  /* Fix cut labels in plots #134 */
-  padding: 0px;
+    /* Fix cut labels in plots #134 */
+    padding: 0px;
 }
 
 /*==================================================================================================
@@ -2603,32 +2622,32 @@ SKETCHER
 ==================================================================================================*/
 
 Gui--StatefulLabel[state="empty_sketch"] {
-  color : rgba(255,255,255,127); /* 50% opacity white */
+    color : rgba(255,255,255,127); /* 50% opacity white */
 }
 Gui--StatefulLabel[state="under_constrained"] {
-  color : rgba(255,255,255,255); /* White */
+    color : rgba(255,255,255,255); /* White */
 }
 Gui--StatefulLabel[state="conflicting_constraints"] {
-  color : rgba(255,0,0,255); /* Red */
+    color : rgba(255,0,0,255); /* Red */
 }
 Gui--StatefulLabel[state="malformed_constraints"] {
-  color : rgba(255,0,0,255); /* Red */
+    color : rgba(255,0,0,255); /* Red */
 }
 Gui--StatefulLabel[state="redundant_constraints"] {
-  color : rgba(255,69,0,255); /* Orange red */
+    color : rgba(255,69,0,255); /* Orange red */
 }
 Gui--StatefulLabel[state="partially_redundant_constraints"] {
-  color : rgba(65,105,225,255); /* Royal blue */
+    color : rgba(65,105,225,255); /* Royal blue */
 }
 Gui--StatefulLabel[state="solver_failed"] {
-  color : rgba(255,0,0,255); /* Red */
-  font-weight: bold;
+    color : rgba(255,0,0,255); /* Red */
+    font-weight: bold;
 }
 Gui--StatefulLabel[state="fully_constrained"] {
-  color : rgba(0,255,0,255); /* Green */
-  font-weight: bold;
+    color : rgba(0,255,0,255); /* Green */
+    font-weight: bold;
 }
 Gui--UrlLabel {
-  color : rgba(0,91,255,255); /* Deep sky blue */
-  text-decoration : underline;
+    color : rgba(0,91,255,255); /* Deep sky blue */
+    text-decoration : underline;
 }

--- a/Darker/Darker.cfg
+++ b/Darker/Darker.cfg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<FCParameters>
+  <FCParamGroup Name="Root">
+    <FCParamGroup Name="BaseApp">
+      <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Arch">
+            <FCUInt Name="WallColor" Value="3604403967"/>
+            <FCUInt Name="StructureColor" Value="2527705855"/>
+            <FCUInt Name="RebarColor" Value="3111475967"/>
+            <FCUInt Name="WindowColor" Value="556614399"/>
+            <FCUInt Name="WindowGlassColor" Value="1572326399"/>
+            <FCUInt Name="PanelColor" Value="3416289279"/>
+            <FCUInt Name="ColorHelpers" Value="1347440895"/>
+            <FCUInt Name="defaultSpaceColor" Value="4280090879"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Draft">
+            <FCInt Name="gridTransparency" Value="0"/>
+            <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="gridColor" Value="4294967295"/>
+            <FCUInt Name="snapcolor" Value="4294967295"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9b4de6</FCText>
+          </FCParamGroup>
+          <FCParamGroup Name="Start">
+            <FCUInt Name="BackgroundColor1" Value="1010580735"/>
+            <FCUInt Name="BackgroundTextColor" Value="4294703103"/>
+            <FCUInt Name="PageColor" Value="858993663"/>
+            <FCUInt Name="PageTextColor" Value="3570717951"/>
+            <FCUInt Name="BoxColor" Value="1583243007"/>
+            <FCUInt Name="LinkColor" Value="1437270015"/>
+            <FCUInt Name="BackgroundColor2" Value="2141107711"/>
+          </FCParamGroup>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="3570717951"/>
+          <FCUInt Name="colorLogging" Value="1437270015"/>
+          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="3570717696"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="1453118976"/>
+          <FCUInt Name="Comment" Value="1788433664"/>
+          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Number" Value="3050219520"/>
+          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="1321840640"/>
+          <FCUInt Name="Define name" Value="3705448960"/>
+          <FCUInt Name="Operator" Value="3570717696"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4252787200"/>
+          <FCUInt Name="Current line highlight" Value="524114944"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
+          <FCUInt Name="SketchVertexColor" Value="4294967295"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
+          <FCUInt Name="EditedVertexColor" Value="4280680703"/>
+          <FCUInt Name="ConstructionColor" Value="746455039"/>
+          <FCUInt Name="ExternalColor" Value="3425924095"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
+          <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="11206655"/>
+          <FCUInt Name="ConstrainedDimColor" Value="4278255615"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4286523135"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/>
+          <FCUInt Name="CursorTextColor" Value="1437270015"/>
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
+          <FCUInt Name="CreateLineColor" Value="3435973887"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="1"/>
+          <FCBool Name="UseBackgroundColorMid" Value="1"/>
+          <FCUInt Name="BacklightColor" Value="4294967295"/>
+          <FCUInt Name="BackgroundColor" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor2" Value="2088533247"/>
+          <FCUInt Name="BackgroundColor3" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor4" Value="2088533247"/>
+          <FCUInt Name="HighlightColor" Value="327679"/>
+          <FCUInt Name="SelectionColor" Value="16711935"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="1434171135"/>
+          <FCUInt Name="TreeActiveColor" Value="3465640191"/>
+        </FCParamGroup>
+        <FCParamGroup Name="MainWindow">
+          <FCBool Name="TiledBackground" Value="0"/>
+          <FCText Name="StyleSheet">Darker.qss</FCText>
+        </FCParamGroup>
+      </FCParamGroup>
+    </FCParamGroup>
+  </FCParamGroup>
+</FCParameters>

--- a/Light-modern/Light-modern.cfg
+++ b/Light-modern/Light-modern.cfg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<FCParameters>
+  <FCParamGroup Name="Root">
+    <FCParamGroup Name="BaseApp">
+      <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Start">
+            <FCUInt Name="BackgroundColor1" Value="4143380223"/>
+            <FCUInt Name="BackgroundTextColor" Value="4294703103"/>
+            <FCUInt Name="PageColor" Value="4294967295"/>
+            <FCUInt Name="PageTextColor" Value="255"/>
+            <FCUInt Name="BoxColor" Value="3974950143"/>
+            <FCUInt Name="LinkColor" Value="1437270015"/>
+            <FCUInt Name="BackgroundColor2" Value="2141107711"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#feff9e</FCText>
+          </FCParamGroup>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="1684301055"/>
+          <FCUInt Name="colorLogging" Value="1437270015"/>
+          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="1903259904"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="1453118976"/>
+          <FCUInt Name="Comment" Value="1788433664"/>
+          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Number" Value="3050219520"/>
+          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="1321840640"/>
+          <FCUInt Name="Define name" Value="3705448960"/>
+          <FCUInt Name="Operator" Value="3570717696"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4252787200"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCBool Name="EnableBacklight" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="1"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="UseBackgroundColorMid" Value="1"/>
+          <FCUInt Name="AnnotationTextColor" Value="3823363071"/>
+          <FCUInt Name="BackgroundColor" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor2" Value="3284386815"/>
+          <FCUInt Name="BackgroundColor3" Value="4143380223"/>
+          <FCUInt Name="BackgroundColor4" Value="3284386815"/>
+          <FCUInt Name="BacklightColor" Value="4294967295"/>
+          <FCUInt Name="BoundingBoxColor" Value="4294967295"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
+          <FCUInt Name="HighlightColor" Value="327679"/>
+          <FCUInt Name="SelectionColor" Value="16711935"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="2327243263"/>
+          <FCUInt Name="TreeActiveColor" Value="3707830271"/>
+        </FCParamGroup>
+        <FCParamGroup Name="MainWindow">
+          <FCBool Name="TiledBackground" Value="0"/>
+          <FCText Name="StyleSheet">Light-modern.qss</FCText>
+        </FCParamGroup>
+      </FCParamGroup>
+    </FCParamGroup>
+  </FCParamGroup>
+
+</FCParameters>

--- a/ProDark/ProDark.cfg
+++ b/ProDark/ProDark.cfg
@@ -103,4 +103,3 @@
     </FCParamGroup>
   </FCParamGroup>
 </FCParameters>
-

--- a/ProDark/ProDark.cfg
+++ b/ProDark/ProDark.cfg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<FCParameters>
+  <FCParamGroup Name="Root">
+    <FCParamGroup Name="BaseApp">
+      <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Mod">
+          <FCParamGroup Name="Arch">
+            <FCUInt Name="WallColor" Value="3604403967"/>
+            <FCUInt Name="StructureColor" Value="2527705855"/>
+            <FCUInt Name="RebarColor" Value="3111475967"/>
+            <FCUInt Name="WindowColor" Value="556614399"/>
+            <FCUInt Name="WindowGlassColor" Value="1572326399"/>
+            <FCUInt Name="PanelColor" Value="3416289279"/>
+            <FCUInt Name="ColorHelpers" Value="1347440895"/>
+            <FCUInt Name="defaultSpaceColor" Value="4280090879"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Draft">
+            <FCInt Name="gridTransparency" Value="0"/>
+            <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="gridColor" Value="4294967295"/>
+            <FCUInt Name="snapcolor" Value="4294967295"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9b4de6</FCText>
+          </FCParamGroup>
+          <FCParamGroup Name="Start">
+            <FCUInt Name="BackgroundColor1" Value="1010580735"/>
+            <FCUInt Name="BackgroundTextColor" Value="4294703103"/>
+            <FCUInt Name="PageColor" Value="858993663"/>
+            <FCUInt Name="PageTextColor" Value="3570717951"/>
+            <FCUInt Name="BoxColor" Value="1583243007"/>
+            <FCUInt Name="LinkColor" Value="1437270015"/>
+            <FCUInt Name="BackgroundColor2" Value="2141107711"/>
+          </FCParamGroup>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="3570717951"/>
+          <FCUInt Name="colorLogging" Value="1437270015"/>
+          <FCUInt Name="colorWarning" Value="4252787455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="3570717696"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="1453118976"/>
+          <FCUInt Name="Comment" Value="1788433664"/>
+          <FCUInt Name="Block comment" Value="3465639936"/>
+          <FCUInt Name="Number" Value="3050219520"/>
+          <FCUInt Name="String" Value="3465639936"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="1321840640"/>
+          <FCUInt Name="Define name" Value="3705448960"/>
+          <FCUInt Name="Operator" Value="3570717696"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4252787200"/>
+          <FCUInt Name="Current line highlight" Value="524114944"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
+          <FCUInt Name="SketchVertexColor" Value="4294967295"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
+          <FCUInt Name="EditedVertexColor" Value="4280680703"/>
+          <FCUInt Name="ConstructionColor" Value="746455039"/>
+          <FCUInt Name="ExternalColor" Value="3425924095"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
+          <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="11206655"/>
+          <FCUInt Name="ConstrainedDimColor" Value="4278255615"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4286523135"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/>
+          <FCUInt Name="CursorTextColor" Value="1437270015"/>
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
+          <FCUInt Name="CreateLineColor" Value="3435973887"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="1"/>
+          <FCBool Name="UseBackgroundColorMid" Value="1"/>
+          <FCUInt Name="BacklightColor" Value="4294967295"/>
+          <FCUInt Name="BackgroundColor" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor2" Value="2088533247"/>
+          <FCUInt Name="BackgroundColor3" Value="1010580735"/>
+          <FCUInt Name="BackgroundColor4" Value="2088533247"/>
+          <FCUInt Name="HighlightColor" Value="327679"/>
+          <FCUInt Name="SelectionColor" Value="16711935"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="1434171135"/>
+          <FCUInt Name="TreeActiveColor" Value="3465640191"/>
+        </FCParamGroup>
+        <FCParamGroup Name="MainWindow">
+          <FCBool Name="TiledBackground" Value="0"/>
+          <FCText Name="StyleSheet">ProDark.qss</FCText>
+        </FCParamGroup>
+      </FCParamGroup>
+    </FCParamGroup>
+  </FCParamGroup>
+</FCParameters>
+

--- a/ProDark/ProDark.qss
+++ b/ProDark/ProDark.qss
@@ -1535,6 +1535,12 @@ QPushButton:focus {
     border: 1px solid #f5f5f5;
 }
 
+#CreateNewRow > QPushButton { // linked to https://github.com/FreeCAD/FreeCAD/pull/15356
+  /* Reset min width to default */
+  min-width: -1;
+  min-height: 50px;
+}
+
 QPushButton:disabled,
 QPushButton:disabled:checked {
     color: #f5f5f5;

--- a/ProDark/ProDark.qss
+++ b/ProDark/ProDark.qss
@@ -1535,7 +1535,7 @@ QPushButton:focus {
     border: 1px solid #f5f5f5;
 }
 
-#CreateNewRow > QPushButton { // linked to https://github.com/FreeCAD/FreeCAD/pull/15356
+#CreateNewRow > QPushButton { /* linked to https://github.com/FreeCAD/FreeCAD/pull/15356 */
   /* Reset min width to default */
   min-width: -1;
   min-height: 50px;


### PR DESCRIPTION
Change based on https://github.com/FreeCAD/FreeCAD/pull/15356

Before this PR:

![Screenshot from 2024-07-11 11-47-31](https://github.com/FreeCAD/FreeCAD-themes/assets/46537884/c7499333-60a8-4b26-aa57-87677116e373)

After:

![Screenshot from 2024-07-11 12-34-03](https://github.com/FreeCAD/FreeCAD-themes/assets/46537884/c87d25a4-9735-4c3b-ac9a-04c18546282d)


Also fix formatting inconsistencies in Dark-modern to be four space indentation.