### PR TITLE
[Behave-dark] Fix Part > GeometryCheck buttons

### DIFF
--- a/Behave-dark/Behave-dark.qss
+++ b/Behave-dark/Behave-dark.qss
@@ -2558,3 +2558,8 @@ QLabel[objectName="labelStatus"] {
     font-weight: bold;
     background-color: #2C333D;
 }
+
+QDialogButtonBox QPushButton {
+    min-width: 24px;
+    padding: 4px 6px;
+}


### PR DESCRIPTION
Currently the Geometry Check buttons are too widedly spaced so only the `Run Check` button left edge can be seen:

![CheckGeometry_Before](https://github.com/user-attachments/assets/132c6bd5-b6a6-48b1-8059-5486715b8af2)

After fix applied:

![CheckGeometry_After](https://github.com/user-attachments/assets/25962090-2746-4af7-8de6-46e916accd1f)
