### PR TITLE
FreeCAD-themes: remove icon in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,6 @@
     <maintainer email="themes@freecad.org">The FreeCAD Team</maintainer>
     <license file="LICENSE">LGPL-2.1-or-later</license>
     <url type="repository" branch="main">https://github.com/FreeCAD/FreeCAD-themes</url>
-    <icon>resources/icons/themes.svg</icon>
 
     <content>
         <preferencepack>

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
     <maintainer email="themes@freecad.org">The FreeCAD Team</maintainer>
     <license file="LICENSE">LGPL-2.1-or-later</license>
     <url type="repository" branch="main">https://github.com/FreeCAD/FreeCAD-themes</url>
+    <!-- No icon yet <icon></icon> -->
 
     <content>
         <preferencepack>


### PR DESCRIPTION
Fixes #17 

The `<icon>` path does not exist in the repo. Update the metadata so it does not provide a wrong path.

The Addon Manager already supports an icon placeholder fallback when the `<icon>` is null or wrong:

<img width="854" height="689" alt="addon" src="https://github.com/user-attachments/assets/4a71bcae-d6d1-4dfc-b9c5-211dd411fda5" />

A new [web Addon catalog](https://marcuspollio.github.io/FreeCAD-website/addons/) could use the same metadata, so better provide no icon (see "FreeCAD documentation" in green) rather than a wrong path (see "FreeCAD-themes" in red where `alt` is used instead):

![web](https://github.com/user-attachments/assets/62a67ae5-d2d9-4b5a-8a08-3107400c12eb)

Another approach is to provide an icon for FreeCAD-themes and indicate that as metadata. Any cool idea? 😏
