### PR TITLE
[Behave-dark_1_1_Plus] fix treeview disabled items, ensure enabled checkboxes/radioboxes are not using...

### DIFF
--- a/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.cfg
+++ b/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.cfg
@@ -85,6 +85,7 @@
               <FCUInt Name="NormalColor" Value="255"/>
               <FCUInt Name="PreSelectColor" Value="4240710143"/>
               <FCUInt Name="SelectColor" Value="1958221567"/>
+              <FCUInt Name="LightTextColor" Value="4294967295"/>
             </FCParamGroup>
             <FCParamGroup Name="Decorations">
               <FCUInt Name="CenterColor" Value="255"/>
@@ -106,7 +107,7 @@
           <FCUInt Name="ThemeAccentColor3" Value="2344484863"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
-          <FCInt Name="FontSize" Value="11"/>
+          <FCInt Name="FontSize" Value="10"/>
           <FCInt Name="ItemBackgroundPadding" Value="11"/>
           <FCUInt Name="TreeActiveColor" Value="899696639"/>
           <FCUInt Name="TreeEditColor" Value="1434171135"/>

--- a/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.qss
+++ b/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.qss
@@ -1747,7 +1747,13 @@ QRadioButton::indicator:checked {
     image:url(qss:images_dark-light/radiobutton_light.svg);
 }
 
-QRadioButton,
+QRadioButton {
+    color: @ThemeAccentColor3;
+    padding: 3px;
+    outline: none;
+    background-color: transparent;
+}
+
 QRadioButton:disabled {
     color:  @TextDisabledColor;
     padding: 3px;
@@ -1780,7 +1786,13 @@ QRadioButton:focus {
 /*==================================================================================================
 Checkbox
 ==================================================================================================*/
-QCheckBox,
+QCheckBox {
+    color: @ThemeAccentColor3;
+    padding: 3px;
+    outline: none;
+    background-color: transparent;
+}
+
 QCheckBox:disabled {
     color:  @TextDisabledColor;
     padding: 3px;
@@ -2592,3 +2604,9 @@ QMenu, QMenu::item, QMenu::item:hover {
     font-family: Ubuntu;
     font-size: 10pt;
 }
+
+QTreeView:disabled,
+QTreeView::indicator:disabled {
+    color: @TextDisabledColor;
+}
+

--- a/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.qss
+++ b/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.qss
@@ -2609,4 +2609,3 @@ QTreeView:disabled,
 QTreeView::indicator:disabled {
     color: @TextDisabledColor;
 }
-

--- a/Behave-dark_1_1_Plus/parameters/Behave-dark_1_1_Plus.yaml
+++ b/Behave-dark_1_1_Plus/parameters/Behave-dark_1_1_Plus.yaml
@@ -65,7 +65,7 @@ SketcherUnderConstrainedColor: "#ffffff"
 StylesheetIconsColor: white
 TabbarBackgroundColor: "@PrimaryColorDarken5"
 Teal: "#588AC1"
-TextDisabledColor: darken(@TextForegroundColor,40)
+TextDisabledColor: "#436D9B"
 TextEditFieldBackgroundColor: "@PrimaryColor"
 TextForegroundColor: "#ffffff"
 TextSelectBackgroundColor: darken(@AccentColor,100)


### PR DESCRIPTION
...disabled text color. Also ensure TechDraw `LightTextColor` is set after user has changed from another theme.