### PR TITLE
Set ReadOnly QLineEdit the same as disabled text

### DIFF
--- a/Behave-dark/Behave-dark.qss
+++ b/Behave-dark/Behave-dark.qss
@@ -1343,6 +1343,11 @@ QDateTimeEdit:disabled {
     border-color: #232932; /* same as enabled color */
 }
 
+QLineEdit[readOnly="true"] {
+    color: #565d68; /*#588AC1;*/
+    background-color: #232932; /* main background color */
+}
+
 QAbstractSpinBox:up-button,
 QSpinBox:up-button,
 QDoubleSpinBox:up-button,

--- a/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.qss
+++ b/Behave-dark_1_1_Plus/Behave-dark_1_1_Plus.qss
@@ -1337,6 +1337,11 @@ QDateTimeEdit:disabled {
     border-color: @NearlyBlack; /* same as enabled color */
 }
 
+QLineEdit[readOnly="true"] {
+    color: #565d68; /*#588AC1;*/
+    background-color: #232932; /* main background color */
+}
+
 QAbstractSpinBox:up-button,
 QSpinBox:up-button,
 QDoubleSpinBox:up-button,

--- a/Dark-contrast/Dark-contrast.qss
+++ b/Dark-contrast/Dark-contrast.qss
@@ -1247,6 +1247,11 @@ QDateTimeEdit:disabled {
     border-color: black; /* same as enabled color */
 }
 
+QLineEdit[readOnly="true"] {
+    color: #545454;
+    background-color: black; /* same as enabled color */
+}
+
 QAbstractSpinBox:up-button,
 QSpinBox:up-button,
 QDoubleSpinBox:up-button,

--- a/Dark-modern/Dark-modern.qss
+++ b/Dark-modern/Dark-modern.qss
@@ -1818,6 +1818,11 @@ QLineEdit:selected {
     color: white;
 }
 
+QLineEdit[readOnly="true"] {
+    background-color: #696968;
+    color: #353535;
+}
+
 /* QTabWiget --------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabbar

--- a/Darker/Darker.qss
+++ b/Darker/Darker.qss
@@ -1796,6 +1796,11 @@ QLineEdit:selected {
   color: white;
 }
 
+QLineEdit[readOnly="true"] {
+  background-color: #696968;
+  color: #353535;
+}
+
 /* QTabWiget --------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabbar

--- a/Light-modern/Light-modern.qss
+++ b/Light-modern/Light-modern.qss
@@ -1802,6 +1802,11 @@ QLineEdit:selected {
   color: black;
 }
 
+QLineEdit[readOnly="true"] {
+  background-color: #f6f6f6;
+  color: #515151;
+}
+
 /* QTabWiget --------------------------------------------------------------
 
 https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabbar

--- a/ProDark/ProDark.qss
+++ b/ProDark/ProDark.qss
@@ -1340,6 +1340,11 @@ QDateTimeEdit:disabled {
     border-color: #2a2a2a; /* same as enabled color */
 }
 
+QLineEdit[readOnly="true"] {
+    color: #f5f5f5;
+    background-color: #2a2a2a;;
+}
+
 QAbstractSpinBox:up-button,
 QSpinBox:up-button,
 QDoubleSpinBox:up-button,


### PR DESCRIPTION
Example:

<img width="601" height="574" alt="ProjInfo_ReadOnlyText" src="https://github.com/user-attachments/assets/7728276d-51a5-4c90-93e7-a3dcd3af6819" />


@chennes with reference to your [PR](https://github.com/FreeCAD/FreeCAD/pull/31686)